### PR TITLE
fix: kanboard TUI overlay wiring + info-screen Kitty keyboard protocol

### DIFF
--- a/packages/info-screen/tui/info-overlay.ts
+++ b/packages/info-screen/tui/info-overlay.ts
@@ -7,489 +7,556 @@
  * Shows humanized "last updated" timestamps.
  */
 
-import type { Component } from "@mariozechner/pi-tui";
-import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import type { Theme } from "@mariozechner/pi-coding-agent";
-import { infoRegistry } from "../registry.js";
+import type { Component } from "@mariozechner/pi-tui";
+import {
+	matchesKey,
+	truncateToWidth,
+	visibleWidth,
+	wrapTextWithAnsi,
+} from "@mariozechner/pi-tui";
 import { getInfoSettings } from "../config.js";
-import type { InfoGroup, GroupData } from "../types.js";
+import { infoRegistry } from "../registry.js";
+import type { GroupData, InfoGroup } from "../types.js";
 
 /** Tab color palette */
 const TAB_FG: Array<"accent" | "success" | "warning" | "error"> = [
-  "accent",
-  "success",
-  "warning",
-  "error",
+	"accent",
+	"success",
+	"warning",
+	"error",
 ];
 
 /** Humanize a duration in ms to a short string */
 function humanizeAge(ms: number): string {
-  if (ms <= 0) return "never";
-  const seconds = Math.floor(ms / 1000);
-  if (seconds < 5) return "just now";
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  return `${hours}h ago`;
+	if (ms <= 0) return "never";
+	const seconds = Math.floor(ms / 1000);
+	if (seconds < 5) return "just now";
+	if (seconds < 60) return `${seconds}s ago`;
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	return `${hours}h ago`;
 }
 
 /**
  * Info overlay component with cache-first reactive model.
  */
 export class InfoOverlay implements Component {
-  private groups: InfoGroup[] = [];
-  private activeTabIndex = 0;
-  private groupData = new Map<string, GroupData>();
-  private groupLoading = new Map<string, boolean>();
-  private scrollOffset = 0;
-  private tabScrollOffset = 0;
-  private lastGlobalUpdate = 0;
-  private unsubscribers: Array<() => void> = [];
-  private _destroyed = false;
-
-  onClose?: () => void;
-  requestRender?: () => void;
-
-  private theme: Theme | null = null;
-
-  setTheme(theme: Theme): void {
-    this.theme = theme;
-  }
-
-  constructor() {
-    // Load groups synchronously (they're already registered)
-    this.groups = infoRegistry.getAllGroups();
-    this.applyOrder();
-
-    // Seed cache with any existing data (instant display)
-    for (const group of this.groups) {
-      const cached = infoRegistry.getCachedData(group.id);
-      if (cached) {
-        this.groupData.set(group.id, cached);
-      }
-      this.groupLoading.set(group.id, true);
-    }
-
-    // Subscribe to per-group updates for reactive rendering
-    this.unsubscribers.push(
-      infoRegistry.subscribeAll((groupId, data) => {
-        if (this._destroyed) return;
-        // Skip empty data from registration notifications — syncGroups()
-        // will trigger the real fetch.
-        if (Object.keys(data).length === 0) {
-          this.requestRender?.();
-          return;
-        }
-        this.groupData.set(groupId, data);
-        this.groupLoading.set(groupId, false);
-        this.lastGlobalUpdate = Date.now();
-        this.requestRender?.();
-      })
-    );
-
-    // Start background fetch for all groups (non-blocking)
-    this.fetchAllBackground();
-  }
-
-  /**
-   * Fetch all groups in background. Each resolves independently.
-   */
-  private async fetchAllBackground(): Promise<void> {
-    for (const group of this.groups) {
-      // Fire each fetch independently — don't await sequentially
-      infoRegistry.getGroupData(group.id).then(() => {
-        this.groupLoading.set(group.id, false);
-      }).catch(() => {
-        this.groupLoading.set(group.id, false);
-      });
-    }
-  }
-
-  /**
-   * Handle late-arriving groups (e.g., subagents announces after boot).
-   */
-  private syncGroups(): void {
-    const allGroups = infoRegistry.getAllGroups();
-    const hadNewGroups = allGroups.length !== this.groups.length;
-    if (hadNewGroups) {
-      this.groups = allGroups;
-      this.applyOrder();
-    }
-
-    // Ensure every group has real (non-empty) data.
-    // Registration notifications inject `{}` to trigger re-sync; we must
-    // not treat that as fetched data or the stats render as "—".
-    for (const group of this.groups) {
-      const existing = this.groupData.get(group.id);
-      const hasRealData = existing && Object.keys(existing).length > 0;
-      if (!hasRealData) {
-        const cached = infoRegistry.getCachedData(group.id);
-        if (cached && Object.keys(cached).length > 0) {
-          this.groupData.set(group.id, cached);
-        } else if (!this.groupLoading.get(group.id)) {
-          this.groupLoading.set(group.id, true);
-          infoRegistry.getGroupData(group.id).then((data) => {
-            this.groupData.set(group.id, data);
-            this.groupLoading.set(group.id, false);
-            this.lastGlobalUpdate = Date.now();
-            this.requestRender?.();
-          }).catch(() => {
-            this.groupLoading.set(group.id, false);
-          });
-        }
-      }
-    }
-  }
-
-  private applyOrder(): void {
-    const settings = getInfoSettings();
-    if (settings.groupOrder && settings.groupOrder.length > 0) {
-      const order = settings.groupOrder;
-      this.groups.sort((a, b) => {
-        const ai = order.indexOf(a.id);
-        const bi = order.indexOf(b.id);
-        return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
-      });
-    }
-  }
-
-  /**
-   * Cleanup subscriptions.
-   */
-  destroy(): void {
-    this._destroyed = true;
-    for (const unsub of this.unsubscribers) {
-      unsub();
-    }
-    this.unsubscribers = [];
-  }
-
-  invalidate(): void {
-    this.syncGroups();
-  }
-
-  handleInput(data: string): void {
-    if (data === "\x1b[C" || data === "l") {
-      this.activeTabIndex = (this.activeTabIndex + 1) % this.groups.length;
-      this.scrollOffset = 0;
-    } else if (data === "\x1b[D" || data === "h") {
-      this.activeTabIndex = (this.activeTabIndex - 1 + this.groups.length) % this.groups.length;
-      this.scrollOffset = 0;
-    } else if (data === "\x1b[B" || data === "j") {
-      this.scrollOffset++;
-    } else if (data === "\x1b[A" || data === "k") {
-      this.scrollOffset = Math.max(0, this.scrollOffset - 1);
-    } else if (data === "g") {
-      this.scrollOffset = 0;
-    } else if (data === "G") {
-      this.scrollOffset = Infinity;
-    } else if (data === "r") {
-      // Manual refresh
-      this.refreshActiveGroup();
-    } else if (data === "R") {
-      // Refresh all
-      this.refreshAll();
-    } else if (data === "q" || data === "\x1b") {
-      this.destroy();
-      this.onClose?.();
-    }
-  }
-
-  private refreshActiveGroup(): void {
-    const group = this.groups[this.activeTabIndex];
-    if (!group) return;
-    this.groupLoading.set(group.id, true);
-    this.requestRender?.();
-    infoRegistry.refreshGroup(group.id);
-  }
-
-  private refreshAll(): void {
-    for (const group of this.groups) {
-      this.groupLoading.set(group.id, true);
-    }
-    this.requestRender?.();
-    infoRegistry.refreshAll();
-  }
-
-  render(width: number): string[] {
-    // Sync groups in case late arrivals
-    this.syncGroups();
-
-    if (this.groups.length === 0) {
-      return this.renderEmpty(width);
-    }
-
-    return this.renderDashboard(width);
-  }
-
-  // ─── Theme helpers ───────────────────────────────────────────────────
-
-  private fg(color: string, text: string): string {
-    if (this.theme) return this.theme.fg(color as any, text);
-    const c: Record<string, string> = {
-      accent: "\x1b[36m", success: "\x1b[32m", warning: "\x1b[33m",
-      error: "\x1b[31m", dim: "\x1b[2m", borderMuted: "\x1b[90m",
-    };
-    return `${c[color] ?? ""}${text}\x1b[0m`;
-  }
-
-  private bold(text: string): string {
-    return this.theme ? this.theme.bold(text) : `\x1b[1m${text}\x1b[0m`;
-  }
-
-  private bg(color: string, text: string): string {
-    return this.theme ? this.theme.bg(color as any, text) : text;
-  }
-
-  private frameLine(content: string, innerWidth: number): string {
-    const truncated = truncateToWidth(content, innerWidth, "");
-    const padding = Math.max(0, innerWidth - visibleWidth(truncated));
-    return `${this.fg("borderMuted", "│")}${truncated}${" ".repeat(padding)}${this.fg("borderMuted", "│")}`;
-  }
-
-  private ruleLine(innerWidth: number): string {
-    return this.fg("borderMuted", `├${"─".repeat(innerWidth)}┤`);
-  }
-
-  private borderLine(innerWidth: number, edge: "top" | "bottom"): string {
-    const left = edge === "top" ? "┌" : "└";
-    const right = edge === "top" ? "┐" : "┘";
-    return this.fg("borderMuted", `${left}${"─".repeat(innerWidth)}${right}`);
-  }
-
-  private getDialogHeight(): number {
-    const terminalRows = process.stdout.rows ?? 30;
-    return Math.max(18, Math.min(32, Math.floor(terminalRows * 0.78)));
-  }
-
-  // ─── State views ─────────────────────────────────────────────────────
-
-  private renderEmpty(width: number): string[] {
-    const innerWidth = Math.max(22, width - 2);
-    const lines: string[] = [];
-    lines.push(this.borderLine(innerWidth, "top"));
-    lines.push(this.frameLine(this.fg("accent", this.bold("📊 UniPi Info Screen")), innerWidth));
-    lines.push(this.ruleLine(innerWidth));
-    lines.push(this.frameLine(this.fg("dim", "No groups registered."), innerWidth));
-    lines.push(this.frameLine(this.fg("dim", "Modules will register groups on startup."), innerWidth));
-    for (let i = 0; i < 4; i++) lines.push(this.frameLine("", innerWidth));
-    lines.push(this.ruleLine(innerWidth));
-    lines.push(this.frameLine(this.fg("dim", "q/Esc close · r refresh"), innerWidth));
-    lines.push(this.borderLine(innerWidth, "bottom"));
-    return lines;
-  }
-
-  // ─── Dashboard ───────────────────────────────────────────────────────
-
-  private renderDashboard(width: number): string[] {
-    const innerWidth = Math.max(22, width - 2);
-    const group = this.groups[this.activeTabIndex];
-    const data = this.groupData.get(group.id) ?? {};
-    const isLoading = this.groupLoading.get(group.id) ?? false;
-
-    const CONTENT_HEIGHT = 12;
-    const lines: string[] = [];
-
-    lines.push(this.borderLine(innerWidth, "top"));
-
-    // Header: group name + loading indicator
-    const loadingDot = isLoading
-      ? ` ${this.fg("warning", "●")}`
-      : ` ${this.fg("success", "●")}`;
-    const headerText = this.fg("accent", this.bold(` ${group.icon} ${group.name} `)) + loadingDot;
-    lines.push(this.frameLine(headerText, innerWidth));
-    lines.push(this.ruleLine(innerWidth));
-
-    // Tab bar
-    lines.push(this.frameLine(this.renderTabBar(innerWidth), innerWidth));
-    lines.push(this.ruleLine(innerWidth));
-
-    // Content with scrolling
-    const contentLines = this.renderGroupContent(innerWidth, group, data);
-    const wrapped = this.wrapLines(contentLines, innerWidth);
-    const maxScroll = Math.max(0, wrapped.length - CONTENT_HEIGHT);
-    this.scrollOffset = Math.min(this.scrollOffset, maxScroll);
-
-    const visible = wrapped.slice(this.scrollOffset, this.scrollOffset + CONTENT_HEIGHT);
-    for (let i = 0; i < CONTENT_HEIGHT; i++) {
-      lines.push(this.frameLine(visible[i] ?? "", innerWidth));
-    }
-
-    // Footer
-    lines.push(this.ruleLine(innerWidth));
-    lines.push(this.frameLine(this.renderFooter(innerWidth, wrapped.length, CONTENT_HEIGHT), innerWidth));
-    lines.push(this.borderLine(innerWidth, "bottom"));
-
-    return lines;
-  }
-
-  private renderTabBar(width: number): string {
-    if (this.groups.length === 0) return "";
-
-    const tabWidths = this.groups.map(g => visibleWidth(` ${g.icon} ${g.name} `));
-    const sepW = visibleWidth(this.fg("borderMuted", "│"));
-    const indicatorSpace = 3;
-    let maxTabs = 0;
-    let totalW = 0;
-    for (let i = 0; i < this.groups.length; i++) {
-      const add = (i > 0 ? sepW : 0) + tabWidths[i]!;
-      if (totalW + add > width - 2 - indicatorSpace) break;
-      totalW += add;
-      maxTabs = i + 1;
-    }
-
-    if (maxTabs >= this.groups.length) {
-      return this.renderAllTabs();
-    }
-
-    if (this.activeTabIndex < this.tabScrollOffset) {
-      this.tabScrollOffset = this.activeTabIndex;
-    } else if (this.activeTabIndex >= this.tabScrollOffset + maxTabs) {
-      this.tabScrollOffset = this.activeTabIndex - maxTabs + 1;
-    }
-    this.tabScrollOffset = Math.max(0, Math.min(this.tabScrollOffset, this.groups.length - maxTabs));
-
-    const tabs: string[] = [];
-    for (let i = this.tabScrollOffset; i < this.tabScrollOffset + maxTabs && i < this.groups.length; i++) {
-      const g = this.groups[i]!;
-      const isActive = i === this.activeTabIndex;
-      const color = TAB_FG[i % TAB_FG.length]!;
-      // Per-tab loading indicator
-      const isLoading = this.groupLoading.get(g.id) ?? false;
-      const dot = isLoading ? this.fg("warning", "●") : "";
-
-      if (isActive) {
-        tabs.push(this.fg(color, this.bold(` ${g.icon} ${g.name} ${dot}`)));
-      } else {
-        tabs.push(this.fg("dim", ` ${g.icon} ${g.name} ${dot}`));
-      }
-    }
-
-    const tabStr = tabs.join(this.fg("borderMuted", "│"));
-    if (this.tabScrollOffset > 0) return `${this.fg("dim", "◀")} ${tabStr}`;
-    if (this.tabScrollOffset + maxTabs < this.groups.length) return `${tabStr} ${this.fg("dim", "▶")}`;
-    return tabStr;
-  }
-
-  private renderAllTabs(): string {
-    const tabs: string[] = [];
-    for (let i = 0; i < this.groups.length; i++) {
-      const g = this.groups[i]!;
-      const isActive = i === this.activeTabIndex;
-      const color = TAB_FG[i % TAB_FG.length]!;
-      const isLoading = this.groupLoading.get(g.id) ?? false;
-      const dot = isLoading ? this.fg("warning", "●") : "";
-
-      if (isActive) {
-        tabs.push(this.fg(color, this.bold(` ${g.icon} ${g.name} ${dot}`)));
-      } else {
-        tabs.push(this.fg("dim", ` ${g.icon} ${g.name} ${dot}`));
-      }
-    }
-    return tabs.join(this.fg("borderMuted", "│"));
-  }
-
-  private renderGroupContent(width: number, group: InfoGroup, data: GroupData): string[] {
-    const lines: string[] = [];
-    const isLoading = this.groupLoading.get(group.id) ?? false;
-    const visibleStats = infoRegistry.getVisibleStats(group.id);
-
-    if (visibleStats.length === 0) {
-      lines.push(`  ${this.fg("dim", "No stats configured for this group.")}`);
-      return lines;
-    }
-
-    // If no data yet and loading, show placeholder per stat
-    if (Object.keys(data).length === 0 && isLoading) {
-      for (const stat of visibleStats) {
-        lines.push(`  ${this.fg("dim", `${stat.label}:`)} ${this.fg("warning", "···")}`);
-      }
-      return lines;
-    }
-
-    const maxLabelLen = Math.max(...visibleStats.map((s) => s.label.length));
-
-    for (const stat of visibleStats) {
-      const statData = data[stat.id];
-      const value = statData?.value ?? "—";
-      const detail = statData?.detail;
-
-      const label = `${stat.label}:`.padEnd(maxLabelLen + 1);
-      let line = `  ${this.fg("dim", label)} ${this.bold(value)}`;
-
-      if (detail) {
-        const detailLines = detail.split("\n");
-        if (detailLines.length === 1) {
-          line += ` ${this.fg("dim", `(${detail})`)}`;
-        } else {
-          lines.push(line);
-          for (const dLine of detailLines) {
-            const indent = " ".repeat(maxLabelLen + 4);
-            let detailLine = `${indent}${dLine}`;
-            if (visibleWidth(detailLine) > width - 2) {
-              detailLine = truncateToWidth(detailLine, width - 2);
-            }
-            lines.push(detailLine);
-          }
-          continue;
-        }
-      }
-
-      if (visibleWidth(line) > width - 2) {
-        line = truncateToWidth(line, width - 2);
-      }
-
-      lines.push(line);
-    }
-
-    return lines;
-  }
-
-  private renderFooter(width: number, totalLines: number, visibleHeight: number): string {
-    const hasScroll = totalLines > visibleHeight;
-    let scrollStr = "";
-    if (hasScroll) {
-      scrollStr = this.fg("dim", `${this.scrollOffset + 1}-${Math.min(this.scrollOffset + visibleHeight, totalLines)}/${totalLines}`);
-    }
-
-    // Last updated for active group
-    const group = this.groups[this.activeTabIndex];
-    const lastUp = infoRegistry.getLastUpdated(group?.id ?? "");
-    const age = lastUp > 0 ? humanizeAge(Date.now() - lastUp) : "loading…";
-
-    const hints = [
-      `${this.fg("accent", "←/→")} tabs`,
-      `${this.fg("success", "↑/↓")} scroll`,
-      `${this.fg("warning", "r")} refresh`,
-      `${this.fg("error", "q/Esc")} close`,
-    ];
-
-    const hintStr = hints.join(`  ${this.fg("borderMuted", "•")}  `);
-
-    // Build right side: age + hints
-    const ageStr = this.fg("dim", `⏱ ${age}`);
-    const rightStr = `${ageStr}  ${this.fg("borderMuted", "│")}  ${hintStr}`;
-
-    const scrollW = visibleWidth(scrollStr);
-    const rightW = visibleWidth(rightStr);
-    const gap = 4;
-    const totalW = scrollW + gap + rightW;
-
-    if (totalW >= width - 2) {
-      return truncateToWidth(rightStr, width - 2);
-    }
-
-    const padding = " ".repeat(Math.max(0, width - 2 - totalW));
-    return scrollStr + padding + rightStr;
-  }
-
-  private wrapLines(lines: string[], innerWidth: number): string[] {
-    const wrapped: string[] = [];
-    for (const line of lines) {
-      if (!line) { wrapped.push(""); continue; }
-      wrapped.push(...wrapTextWithAnsi(line, Math.max(1, innerWidth)));
-    }
-    return wrapped;
-  }
+	private groups: InfoGroup[] = [];
+	private activeTabIndex = 0;
+	private groupData = new Map<string, GroupData>();
+	private groupLoading = new Map<string, boolean>();
+	private scrollOffset = 0;
+	private tabScrollOffset = 0;
+	private lastGlobalUpdate = 0;
+	private unsubscribers: Array<() => void> = [];
+	private _destroyed = false;
+
+	onClose?: () => void;
+	requestRender?: () => void;
+
+	private theme: Theme | null = null;
+
+	setTheme(theme: Theme): void {
+		this.theme = theme;
+	}
+
+	constructor() {
+		// Load groups synchronously (they're already registered)
+		this.groups = infoRegistry.getAllGroups();
+		this.applyOrder();
+
+		// Seed cache with any existing data (instant display)
+		for (const group of this.groups) {
+			const cached = infoRegistry.getCachedData(group.id);
+			if (cached) {
+				this.groupData.set(group.id, cached);
+			}
+			this.groupLoading.set(group.id, true);
+		}
+
+		// Subscribe to per-group updates for reactive rendering
+		this.unsubscribers.push(
+			infoRegistry.subscribeAll((groupId, data) => {
+				if (this._destroyed) return;
+				// Skip empty data from registration notifications — syncGroups()
+				// will trigger the real fetch.
+				if (Object.keys(data).length === 0) {
+					this.requestRender?.();
+					return;
+				}
+				this.groupData.set(groupId, data);
+				this.groupLoading.set(groupId, false);
+				this.lastGlobalUpdate = Date.now();
+				this.requestRender?.();
+			}),
+		);
+
+		// Start background fetch for all groups (non-blocking)
+		this.fetchAllBackground();
+	}
+
+	/**
+	 * Fetch all groups in background. Each resolves independently.
+	 */
+	private async fetchAllBackground(): Promise<void> {
+		for (const group of this.groups) {
+			// Fire each fetch independently — don't await sequentially
+			infoRegistry
+				.getGroupData(group.id)
+				.then(() => {
+					this.groupLoading.set(group.id, false);
+				})
+				.catch(() => {
+					this.groupLoading.set(group.id, false);
+				});
+		}
+	}
+
+	/**
+	 * Handle late-arriving groups (e.g., subagents announces after boot).
+	 */
+	private syncGroups(): void {
+		const allGroups = infoRegistry.getAllGroups();
+		const hadNewGroups = allGroups.length !== this.groups.length;
+		if (hadNewGroups) {
+			this.groups = allGroups;
+			this.applyOrder();
+		}
+
+		// Ensure every group has real (non-empty) data.
+		// Registration notifications inject `{}` to trigger re-sync; we must
+		// not treat that as fetched data or the stats render as "—".
+		for (const group of this.groups) {
+			const existing = this.groupData.get(group.id);
+			const hasRealData = existing && Object.keys(existing).length > 0;
+			if (!hasRealData) {
+				const cached = infoRegistry.getCachedData(group.id);
+				if (cached && Object.keys(cached).length > 0) {
+					this.groupData.set(group.id, cached);
+				} else if (!this.groupLoading.get(group.id)) {
+					this.groupLoading.set(group.id, true);
+					infoRegistry
+						.getGroupData(group.id)
+						.then((data) => {
+							this.groupData.set(group.id, data);
+							this.groupLoading.set(group.id, false);
+							this.lastGlobalUpdate = Date.now();
+							this.requestRender?.();
+						})
+						.catch(() => {
+							this.groupLoading.set(group.id, false);
+						});
+				}
+			}
+		}
+	}
+
+	private applyOrder(): void {
+		const settings = getInfoSettings();
+		if (settings.groupOrder && settings.groupOrder.length > 0) {
+			const order = settings.groupOrder;
+			this.groups.sort((a, b) => {
+				const ai = order.indexOf(a.id);
+				const bi = order.indexOf(b.id);
+				return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+			});
+		}
+	}
+
+	/**
+	 * Cleanup subscriptions.
+	 */
+	destroy(): void {
+		this._destroyed = true;
+		for (const unsub of this.unsubscribers) {
+			unsub();
+		}
+		this.unsubscribers = [];
+	}
+
+	invalidate(): void {
+		this.syncGroups();
+	}
+
+	handleInput(data: string): void {
+		// Tab navigation: right arrow / l
+		if (matchesKey(data, "right") || data === "l") {
+			this.activeTabIndex = (this.activeTabIndex + 1) % this.groups.length;
+			this.scrollOffset = 0;
+		} else if (matchesKey(data, "left") || data === "h") {
+			this.activeTabIndex =
+				(this.activeTabIndex - 1 + this.groups.length) % this.groups.length;
+			this.scrollOffset = 0;
+		} else if (matchesKey(data, "down") || data === "j") {
+			this.scrollOffset++;
+		} else if (matchesKey(data, "up") || data === "k") {
+			this.scrollOffset = Math.max(0, this.scrollOffset - 1);
+		} else if (data === "g") {
+			this.scrollOffset = 0;
+		} else if (data === "G") {
+			this.scrollOffset = Infinity;
+		} else if (data === "r") {
+			// Manual refresh
+			this.refreshActiveGroup();
+		} else if (data === "R") {
+			// Refresh all
+			this.refreshAll();
+		} else if (data === "q" || matchesKey(data, "escape")) {
+			this.destroy();
+			this.onClose?.();
+		}
+	}
+
+	private refreshActiveGroup(): void {
+		const group = this.groups[this.activeTabIndex];
+		if (!group) return;
+		this.groupLoading.set(group.id, true);
+		this.requestRender?.();
+		infoRegistry.refreshGroup(group.id);
+	}
+
+	private refreshAll(): void {
+		for (const group of this.groups) {
+			this.groupLoading.set(group.id, true);
+		}
+		this.requestRender?.();
+		infoRegistry.refreshAll();
+	}
+
+	render(width: number): string[] {
+		// Sync groups in case late arrivals
+		this.syncGroups();
+
+		if (this.groups.length === 0) {
+			return this.renderEmpty(width);
+		}
+
+		return this.renderDashboard(width);
+	}
+
+	// ─── Theme helpers ───────────────────────────────────────────────────
+
+	private fg(color: string, text: string): string {
+		if (this.theme) return this.theme.fg(color as any, text);
+		const c: Record<string, string> = {
+			accent: "\x1b[36m",
+			success: "\x1b[32m",
+			warning: "\x1b[33m",
+			error: "\x1b[31m",
+			dim: "\x1b[2m",
+			borderMuted: "\x1b[90m",
+		};
+		return `${c[color] ?? ""}${text}\x1b[0m`;
+	}
+
+	private bold(text: string): string {
+		return this.theme ? this.theme.bold(text) : `\x1b[1m${text}\x1b[0m`;
+	}
+
+	private bg(color: string, text: string): string {
+		return this.theme ? this.theme.bg(color as any, text) : text;
+	}
+
+	private frameLine(content: string, innerWidth: number): string {
+		const truncated = truncateToWidth(content, innerWidth, "");
+		const padding = Math.max(0, innerWidth - visibleWidth(truncated));
+		return `${this.fg("borderMuted", "│")}${truncated}${" ".repeat(padding)}${this.fg("borderMuted", "│")}`;
+	}
+
+	private ruleLine(innerWidth: number): string {
+		return this.fg("borderMuted", `├${"─".repeat(innerWidth)}┤`);
+	}
+
+	private borderLine(innerWidth: number, edge: "top" | "bottom"): string {
+		const left = edge === "top" ? "┌" : "└";
+		const right = edge === "top" ? "┐" : "┘";
+		return this.fg("borderMuted", `${left}${"─".repeat(innerWidth)}${right}`);
+	}
+
+	private getDialogHeight(): number {
+		const terminalRows = process.stdout.rows ?? 30;
+		return Math.max(18, Math.min(32, Math.floor(terminalRows * 0.78)));
+	}
+
+	// ─── State views ─────────────────────────────────────────────────────
+
+	private renderEmpty(width: number): string[] {
+		const innerWidth = Math.max(22, width - 2);
+		const lines: string[] = [];
+		lines.push(this.borderLine(innerWidth, "top"));
+		lines.push(
+			this.frameLine(
+				this.fg("accent", this.bold("📊 UniPi Info Screen")),
+				innerWidth,
+			),
+		);
+		lines.push(this.ruleLine(innerWidth));
+		lines.push(
+			this.frameLine(this.fg("dim", "No groups registered."), innerWidth),
+		);
+		lines.push(
+			this.frameLine(
+				this.fg("dim", "Modules will register groups on startup."),
+				innerWidth,
+			),
+		);
+		for (let i = 0; i < 4; i++) lines.push(this.frameLine("", innerWidth));
+		lines.push(this.ruleLine(innerWidth));
+		lines.push(
+			this.frameLine(this.fg("dim", "q/Esc close · r refresh"), innerWidth),
+		);
+		lines.push(this.borderLine(innerWidth, "bottom"));
+		return lines;
+	}
+
+	// ─── Dashboard ───────────────────────────────────────────────────────
+
+	private renderDashboard(width: number): string[] {
+		const innerWidth = Math.max(22, width - 2);
+		const group = this.groups[this.activeTabIndex];
+		const data = this.groupData.get(group.id) ?? {};
+		const isLoading = this.groupLoading.get(group.id) ?? false;
+
+		const CONTENT_HEIGHT = 12;
+		const lines: string[] = [];
+
+		lines.push(this.borderLine(innerWidth, "top"));
+
+		// Header: group name + loading indicator
+		const loadingDot = isLoading
+			? ` ${this.fg("warning", "●")}`
+			: ` ${this.fg("success", "●")}`;
+		const headerText =
+			this.fg("accent", this.bold(` ${group.icon} ${group.name} `)) +
+			loadingDot;
+		lines.push(this.frameLine(headerText, innerWidth));
+		lines.push(this.ruleLine(innerWidth));
+
+		// Tab bar
+		lines.push(this.frameLine(this.renderTabBar(innerWidth), innerWidth));
+		lines.push(this.ruleLine(innerWidth));
+
+		// Content with scrolling
+		const contentLines = this.renderGroupContent(innerWidth, group, data);
+		const wrapped = this.wrapLines(contentLines, innerWidth);
+		const maxScroll = Math.max(0, wrapped.length - CONTENT_HEIGHT);
+		this.scrollOffset = Math.min(this.scrollOffset, maxScroll);
+
+		const visible = wrapped.slice(
+			this.scrollOffset,
+			this.scrollOffset + CONTENT_HEIGHT,
+		);
+		for (let i = 0; i < CONTENT_HEIGHT; i++) {
+			lines.push(this.frameLine(visible[i] ?? "", innerWidth));
+		}
+
+		// Footer
+		lines.push(this.ruleLine(innerWidth));
+		lines.push(
+			this.frameLine(
+				this.renderFooter(innerWidth, wrapped.length, CONTENT_HEIGHT),
+				innerWidth,
+			),
+		);
+		lines.push(this.borderLine(innerWidth, "bottom"));
+
+		return lines;
+	}
+
+	private renderTabBar(width: number): string {
+		if (this.groups.length === 0) return "";
+
+		const tabWidths = this.groups.map((g) =>
+			visibleWidth(` ${g.icon} ${g.name} `),
+		);
+		const sepW = visibleWidth(this.fg("borderMuted", "│"));
+		const indicatorSpace = 3;
+		let maxTabs = 0;
+		let totalW = 0;
+		for (let i = 0; i < this.groups.length; i++) {
+			const add = (i > 0 ? sepW : 0) + tabWidths[i]!;
+			if (totalW + add > width - 2 - indicatorSpace) break;
+			totalW += add;
+			maxTabs = i + 1;
+		}
+
+		if (maxTabs >= this.groups.length) {
+			return this.renderAllTabs();
+		}
+
+		if (this.activeTabIndex < this.tabScrollOffset) {
+			this.tabScrollOffset = this.activeTabIndex;
+		} else if (this.activeTabIndex >= this.tabScrollOffset + maxTabs) {
+			this.tabScrollOffset = this.activeTabIndex - maxTabs + 1;
+		}
+		this.tabScrollOffset = Math.max(
+			0,
+			Math.min(this.tabScrollOffset, this.groups.length - maxTabs),
+		);
+
+		const tabs: string[] = [];
+		for (
+			let i = this.tabScrollOffset;
+			i < this.tabScrollOffset + maxTabs && i < this.groups.length;
+			i++
+		) {
+			const g = this.groups[i]!;
+			const isActive = i === this.activeTabIndex;
+			const color = TAB_FG[i % TAB_FG.length]!;
+			// Per-tab loading indicator
+			const isLoading = this.groupLoading.get(g.id) ?? false;
+			const dot = isLoading ? this.fg("warning", "●") : "";
+
+			if (isActive) {
+				tabs.push(this.fg(color, this.bold(` ${g.icon} ${g.name} ${dot}`)));
+			} else {
+				tabs.push(this.fg("dim", ` ${g.icon} ${g.name} ${dot}`));
+			}
+		}
+
+		const tabStr = tabs.join(this.fg("borderMuted", "│"));
+		if (this.tabScrollOffset > 0) return `${this.fg("dim", "◀")} ${tabStr}`;
+		if (this.tabScrollOffset + maxTabs < this.groups.length)
+			return `${tabStr} ${this.fg("dim", "▶")}`;
+		return tabStr;
+	}
+
+	private renderAllTabs(): string {
+		const tabs: string[] = [];
+		for (let i = 0; i < this.groups.length; i++) {
+			const g = this.groups[i]!;
+			const isActive = i === this.activeTabIndex;
+			const color = TAB_FG[i % TAB_FG.length]!;
+			const isLoading = this.groupLoading.get(g.id) ?? false;
+			const dot = isLoading ? this.fg("warning", "●") : "";
+
+			if (isActive) {
+				tabs.push(this.fg(color, this.bold(` ${g.icon} ${g.name} ${dot}`)));
+			} else {
+				tabs.push(this.fg("dim", ` ${g.icon} ${g.name} ${dot}`));
+			}
+		}
+		return tabs.join(this.fg("borderMuted", "│"));
+	}
+
+	private renderGroupContent(
+		width: number,
+		group: InfoGroup,
+		data: GroupData,
+	): string[] {
+		const lines: string[] = [];
+		const isLoading = this.groupLoading.get(group.id) ?? false;
+		const visibleStats = infoRegistry.getVisibleStats(group.id);
+
+		if (visibleStats.length === 0) {
+			lines.push(`  ${this.fg("dim", "No stats configured for this group.")}`);
+			return lines;
+		}
+
+		// If no data yet and loading, show placeholder per stat
+		if (Object.keys(data).length === 0 && isLoading) {
+			for (const stat of visibleStats) {
+				lines.push(
+					`  ${this.fg("dim", `${stat.label}:`)} ${this.fg("warning", "···")}`,
+				);
+			}
+			return lines;
+		}
+
+		const maxLabelLen = Math.max(...visibleStats.map((s) => s.label.length));
+
+		for (const stat of visibleStats) {
+			const statData = data[stat.id];
+			const value = statData?.value ?? "—";
+			const detail = statData?.detail;
+
+			const label = `${stat.label}:`.padEnd(maxLabelLen + 1);
+			let line = `  ${this.fg("dim", label)} ${this.bold(value)}`;
+
+			if (detail) {
+				const detailLines = detail.split("\n");
+				if (detailLines.length === 1) {
+					line += ` ${this.fg("dim", `(${detail})`)}`;
+				} else {
+					lines.push(line);
+					for (const dLine of detailLines) {
+						const indent = " ".repeat(maxLabelLen + 4);
+						let detailLine = `${indent}${dLine}`;
+						if (visibleWidth(detailLine) > width - 2) {
+							detailLine = truncateToWidth(detailLine, width - 2);
+						}
+						lines.push(detailLine);
+					}
+					continue;
+				}
+			}
+
+			if (visibleWidth(line) > width - 2) {
+				line = truncateToWidth(line, width - 2);
+			}
+
+			lines.push(line);
+		}
+
+		return lines;
+	}
+
+	private renderFooter(
+		width: number,
+		totalLines: number,
+		visibleHeight: number,
+	): string {
+		const hasScroll = totalLines > visibleHeight;
+		let scrollStr = "";
+		if (hasScroll) {
+			scrollStr = this.fg(
+				"dim",
+				`${this.scrollOffset + 1}-${Math.min(this.scrollOffset + visibleHeight, totalLines)}/${totalLines}`,
+			);
+		}
+
+		// Last updated for active group
+		const group = this.groups[this.activeTabIndex];
+		const lastUp = infoRegistry.getLastUpdated(group?.id ?? "");
+		const age = lastUp > 0 ? humanizeAge(Date.now() - lastUp) : "loading…";
+
+		const hints = [
+			`${this.fg("accent", "←/→")} tabs`,
+			`${this.fg("success", "↑/↓")} scroll`,
+			`${this.fg("warning", "r")} refresh`,
+			`${this.fg("error", "q/Esc")} close`,
+		];
+
+		const hintStr = hints.join(`  ${this.fg("borderMuted", "•")}  `);
+
+		// Build right side: age + hints
+		const ageStr = this.fg("dim", `⏱ ${age}`);
+		const rightStr = `${ageStr}  ${this.fg("borderMuted", "│")}  ${hintStr}`;
+
+		const scrollW = visibleWidth(scrollStr);
+		const rightW = visibleWidth(rightStr);
+		const gap = 4;
+		const totalW = scrollW + gap + rightW;
+
+		if (totalW >= width - 2) {
+			return truncateToWidth(rightStr, width - 2);
+		}
+
+		const padding = " ".repeat(Math.max(0, width - 2 - totalW));
+		return scrollStr + padding + rightStr;
+	}
+
+	private wrapLines(lines: string[], innerWidth: number): string[] {
+		const wrapped: string[] = [];
+		for (const line of lines) {
+			if (!line) {
+				wrapped.push("");
+				continue;
+			}
+			wrapped.push(...wrapTextWithAnsi(line, Math.max(1, innerWidth)));
+		}
+		return wrapped;
+	}
 }

--- a/packages/kanboard/commands.ts
+++ b/packages/kanboard/commands.ts
@@ -4,81 +4,40 @@
  * Registers kanboard and kanboard-doctor commands.
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { UNIPI_PREFIX, KANBOARD_COMMANDS, KANBOARD_DIRS, UNIPI_EVENTS, emitEvent } from "@pi-unipi/core";
-import { startServer, KanboardServer } from "./server/index.js";
+import { KANBOARD_COMMANDS, UNIPI_PREFIX } from "@pi-unipi/core";
 import { renderKanboardOverlay } from "./tui/kanboard-overlay.js";
-
-/** Module-level reference to running server */
-let runningServer: KanboardServer | null = null;
-
-/** Check if a kanboard server is running via PID file */
-function isPidFileRunning(pidFile: string): boolean {
-  try {
-    if (!fs.existsSync(pidFile)) return false;
-    const pid = parseInt(fs.readFileSync(pidFile, "utf-8").trim(), 10);
-    if (isNaN(pid)) return false;
-    process.kill(pid, 0); // Check if process exists
-    return true;
-  } catch {
-    // Process doesn't exist or can't access PID file
-    try {
-       fs.unlinkSync(pidFile);
-    } catch {}
-    return false;
-  }
-}
 
 /** Register kanboard commands */
 export function registerCommands(pi: ExtensionAPI): void {
-  // kanboard — Toggle server start/stop
-  pi.registerCommand(
-    `${UNIPI_PREFIX}${KANBOARD_COMMANDS.KANBOARD}`,
-    {
-      description: "Toggle kanboard visualization server",
-      handler: async (_args: string, ctx: any) => {
-        const pidFile = path.resolve(KANBOARD_DIRS.PID_FILE);
+	// kanboard — Show kanban board TUI overlay
+	pi.registerCommand(`${UNIPI_PREFIX}${KANBOARD_COMMANDS.KANBOARD}`, {
+		description: "Show kanban board with tasks and status columns",
+		handler: async (_args: string, ctx: any) => {
+			ctx.ui.custom(
+				renderKanboardOverlay({
+					docsRoot: ".unipi/docs",
+					onComplete: () => {},
+				}),
+				{
+					overlay: true,
+					overlayOptions: {
+						width: "80%",
+						minWidth: 60,
+						anchor: "center",
+						margin: 2,
+					},
+				},
+			);
+		},
+	});
 
-        try {
-          // Case 1: We have a live reference in this process
-          if (runningServer) {
-            runningServer.stop();
-            runningServer = null;
-            ctx.ui.notify("Kanboard stopped", "info");
-            return;
-          }
-
-          // Case 2: PID file shows a running instance (from previous process)
-          if (isPidFileRunning(pidFile)) {
-            // PID file exists but we don't have a reference — stale or external.
-            // Remove stale PID file and let user know.
-            try { fs.unlinkSync(pidFile); } catch {}
-            ctx.ui.notify("Kanboard was running in a previous session. PID file cleaned. Run again to start fresh.", "info");
-            return;
-          }
-
-          // Case 3: No running instance — start fresh
-          const { server, url } = await startServer();
-          runningServer = server;
-          ctx.ui.notify(`Kanboard running at ${url}`, "info");
-        } catch (err: any) {
-          ctx.ui.notify(`Kanboard error: ${err.message}`, "error");
-        }
-      },
-    },
-  );
-
-  // kanboard-doctor — Load doctor skill
-  pi.registerCommand(
-    `${UNIPI_PREFIX}${KANBOARD_COMMANDS.KANBOARD_DOCTOR}`,
-    {
-      description: "Diagnose and fix kanboard parser issues",
-      handler: async (_args: string, ctx: any) => {
-        ctx.ui.notify("Loading kanboard-doctor skill...", "info");
-        // The skill will be loaded by the skill system via resources_discover
-      },
-    },
-  );
+	// kanboard-doctor — Load doctor skill
+	pi.registerCommand(`${UNIPI_PREFIX}${KANBOARD_COMMANDS.KANBOARD_DOCTOR}`, {
+		description: "Diagnose and fix kanboard parser issues",
+		handler: async (_args: string, ctx: any) => {
+			ctx.ui.notify("Loading kanboard-doctor skill...", "info");
+			// The skill will be loaded by the skill system via resources_discover
+		},
+	});
 }

--- a/packages/kanboard/tui/kanboard-overlay.ts
+++ b/packages/kanboard/tui/kanboard-overlay.ts
@@ -2,297 +2,342 @@
  * @pi-unipi/kanboard — Kanboard TUI Overlay
  *
  * Two tabs: Tasks list and Kanban Board.
- * Uses pi-tui overlay API (same pattern as MCP add overlay).
+ * Implements pi-tui Component interface for ctx.ui.custom() integration.
  */
 
 import {
-  Key,
-  matchesKey,
-  truncateToWidth,
-  visibleWidth,
+	matchesKey,
+	truncateToWidth,
+	visibleWidth,
 } from "@mariozechner/pi-tui";
-import type { ParsedDoc, ParsedItem, ItemStatus } from "../types.js";
 import { createDefaultRegistry } from "../parser/index.js";
+import type { ItemStatus, ParsedItem } from "../types.js";
 
 type Tab = "tasks" | "board";
 
 interface KanboardState {
-  tab: Tab;
-  tasks: ParsedItem[];
-  taskIndex: number;
-  taskScroll: number;
-  /** Board columns: index into tasks array grouped by status */
-  boardColumns: {
-    todo: number[];
-    inProgress: number[];
-    done: number[];
-  };
-  boardCol: number; // 0=todo, 1=inProgress, 2=done
-  boardIndex: number[];
-  pendingG: boolean;
-  docsRoot: string;
+	tab: Tab;
+	tasks: ParsedItem[];
+	taskIndex: number;
+	taskScroll: number;
+	/** Board columns: index into tasks array grouped by status */
+	boardColumns: {
+		todo: number[];
+		inProgress: number[];
+		done: number[];
+	};
+	boardCol: number; // 0=todo, 1=inProgress, 2=done
+	boardIndex: number[];
+	pendingG: boolean;
+	docsRoot: string;
 }
 
 /** Status icon */
 function statusIcon(status: ItemStatus): string {
-  switch (status) {
-    case "done":
-      return "✓";
-    case "in-progress":
-      return "◐";
-    default:
-      return "○";
-  }
+	switch (status) {
+		case "done":
+			return "✓";
+		case "in-progress":
+			return "◐";
+		default:
+			return "○";
+	}
 }
 
 /** Pad string to visible width */
 function padVisible(content: string, targetWidth: number): string {
-  const pad = Math.max(0, targetWidth - visibleWidth(content));
-  return content + " ".repeat(pad);
+	const pad = Math.max(0, targetWidth - visibleWidth(content));
+	return content + " ".repeat(pad);
 }
 
 /**
- * Render the kanboard overlay.
+ * Kanboard overlay Component for ctx.ui.custom().
+ */
+export class KanboardOverlay {
+	private state: KanboardState;
+	private loaded = false;
+	private _destroyed = false;
+
+	onClose?: () => void;
+	requestRender?: () => void;
+
+	constructor(params?: { docsRoot?: string; onComplete?: () => void }) {
+		this.state = {
+			tab: "tasks",
+			tasks: [],
+			taskIndex: 0,
+			taskScroll: 0,
+			boardColumns: { todo: [], inProgress: [], done: [] },
+			boardCol: 0,
+			boardIndex: [0, 0, 0],
+			pendingG: false,
+			docsRoot: params?.docsRoot ?? ".unipi/docs",
+		};
+		this.onClose = params?.onComplete;
+
+		// Start loading data in background
+		this.ensureLoaded();
+	}
+
+	private async ensureLoaded(): Promise<void> {
+		if (this.loaded) return;
+		const registry = await createDefaultRegistry();
+		const docs = registry.parseAll(this.state.docsRoot);
+		this.state.tasks = docs.flatMap((d) => d.items);
+
+		// Build board columns
+		this.state.boardColumns = { todo: [], inProgress: [], done: [] };
+		this.state.tasks.forEach((item, idx) => {
+			if (item.status === "done") this.state.boardColumns.done.push(idx);
+			else if (item.status === "in-progress")
+				this.state.boardColumns.inProgress.push(idx);
+			else this.state.boardColumns.todo.push(idx);
+		});
+
+		this.state.boardIndex = [0, 0, 0];
+		this.loaded = true;
+		this.requestRender?.();
+	}
+
+	destroy(): void {
+		this._destroyed = true;
+	}
+
+	invalidate(): void {
+		// No cached state to clear
+	}
+
+	handleInput(data: string): void {
+		if (this._destroyed) return;
+
+		// Close
+		if (matchesKey(data, "q") || matchesKey(data, "escape")) {
+			this.destroy();
+			this.onClose?.();
+			return;
+		}
+
+		// Tab switching
+		if (matchesKey(data, "tab") || data === "b") {
+			this.state.tab = this.state.tab === "tasks" ? "board" : "tasks";
+			this.requestRender?.();
+			return;
+		}
+
+		if (data === "t") {
+			this.state.tab = "tasks";
+			this.requestRender?.();
+			return;
+		}
+
+		// Navigation
+		if (this.state.tab === "tasks") {
+			if (matchesKey(data, "down") || data === "j") {
+				this.state.taskIndex = Math.min(
+					this.state.taskIndex + 1,
+					this.state.tasks.length - 1,
+				);
+			} else if (matchesKey(data, "up") || data === "k") {
+				this.state.taskIndex = Math.max(this.state.taskIndex - 1, 0);
+			} else if (data === "g") {
+				if (this.state.pendingG) {
+					this.state.taskIndex = 0;
+					this.state.pendingG = false;
+				} else {
+					this.state.pendingG = true;
+					setTimeout(() => {
+						this.state.pendingG = false;
+					}, 500);
+				}
+			} else if (data === "G") {
+				this.state.taskIndex = this.state.tasks.length - 1;
+			}
+		} else {
+			// Board navigation
+			const cols = [
+				this.state.boardColumns.todo,
+				this.state.boardColumns.inProgress,
+				this.state.boardColumns.done,
+			];
+
+			if (matchesKey(data, "left") || data === "h") {
+				this.state.boardCol = Math.max(0, this.state.boardCol - 1);
+			} else if (matchesKey(data, "right") || data === "l") {
+				this.state.boardCol = Math.min(2, this.state.boardCol + 1);
+			} else if (matchesKey(data, "down") || data === "j") {
+				const col = cols[this.state.boardCol];
+				this.state.boardIndex[this.state.boardCol] = Math.min(
+					this.state.boardIndex[this.state.boardCol] + 1,
+					col.length - 1,
+				);
+			} else if (matchesKey(data, "up") || data === "k") {
+				this.state.boardIndex[this.state.boardCol] = Math.max(
+					this.state.boardIndex[this.state.boardCol] - 1,
+					0,
+				);
+			}
+		}
+
+		this.requestRender?.();
+	}
+
+	render(width: number): string[] {
+		const lines: string[] = [];
+
+		// Header
+		const header = " 📋 Kanboard ";
+		const tabLine = "  [T]asks  |  [B]oard  "
+			.replace(
+				this.state.tab === "tasks" ? "[T]" : "T",
+				this.state.tab === "tasks" ? "▸T" : " T",
+			)
+			.replace(
+				this.state.tab === "board" ? "[B]" : "B",
+				this.state.tab === "board" ? "▸B" : " B",
+			);
+		lines.push(truncateToWidth(header, width));
+		lines.push(truncateToWidth(tabLine, width));
+		lines.push("─".repeat(width));
+
+		const contentHeight = 12;
+		if (this.state.tab === "tasks") {
+			this.renderTasksTab(lines, width, contentHeight);
+		} else {
+			this.renderBoardTab(lines, width, contentHeight);
+		}
+
+		// Footer
+		lines.push("─".repeat(width));
+		const footer = " j/k: navigate  Tab: switch tab  q/Esc: close ";
+		lines.push(truncateToWidth(footer, width));
+
+		return lines;
+	}
+
+	private renderTasksTab(
+		lines: string[],
+		width: number,
+		maxLines: number,
+	): void {
+		if (this.state.tasks.length === 0) {
+			lines.push(truncateToWidth("  No tasks found.", width));
+			return;
+		}
+
+		// Ensure index in range
+		this.state.taskIndex = Math.min(
+			this.state.taskIndex,
+			this.state.tasks.length - 1,
+		);
+		this.state.taskIndex = Math.max(0, this.state.taskIndex);
+
+		// Scroll to keep selected visible
+		if (this.state.taskIndex < this.state.taskScroll)
+			this.state.taskScroll = this.state.taskIndex;
+		if (this.state.taskIndex >= this.state.taskScroll + maxLines) {
+			this.state.taskScroll = this.state.taskIndex - maxLines + 1;
+		}
+
+		const visible = this.state.tasks.slice(
+			this.state.taskScroll,
+			this.state.taskScroll + maxLines,
+		);
+
+		for (let i = 0; i < visible.length; i++) {
+			const item = visible[i];
+			const globalIdx = this.state.taskScroll + i;
+			const selected = globalIdx === this.state.taskIndex;
+			const prefix = selected ? " ▸ " : "   ";
+			const icon = statusIcon(item.status);
+			const source = `[${item.sourceFile}]`;
+			const line = `${prefix}${icon} ${item.text}  ${source}`;
+			lines.push(
+				truncateToWidth(
+					selected ? `\x1b[7m${padVisible(line, width)}\x1b[0m` : line,
+					width,
+				),
+			);
+		}
+	}
+
+	private renderBoardTab(
+		lines: string[],
+		width: number,
+		maxLines: number,
+	): void {
+		const colWidth = Math.floor(width / 3);
+		const cols: Array<{ title: string; indices: number[]; colIdx: number }> = [
+			{ title: "To Do", indices: this.state.boardColumns.todo, colIdx: 0 },
+			{
+				title: "In Progress",
+				indices: this.state.boardColumns.inProgress,
+				colIdx: 1,
+			},
+			{ title: "Done", indices: this.state.boardColumns.done, colIdx: 2 },
+		];
+
+		// Column headers
+		let headerLine = "";
+		for (const col of cols) {
+			const isActive = col.colIdx === this.state.boardCol;
+			const title = isActive ? `▸ ${col.title}` : `  ${col.title}`;
+			headerLine += padVisible(` ${title} (${col.indices.length})`, colWidth);
+		}
+		lines.push(truncateToWidth(headerLine, width));
+		lines.push("─".repeat(width));
+
+		// Column items
+		const maxItems = Math.max(
+			...cols.map((c) => c.indices.length),
+			maxLines - 2,
+		);
+		for (let row = 0; row < Math.min(maxItems, maxLines - 2); row++) {
+			let rowLine = "";
+			for (const col of cols) {
+				const active = col.colIdx === this.state.boardCol;
+				const boardIdx = this.state.boardIndex[col.colIdx] ?? 0;
+				if (row < col.indices.length) {
+					const item = this.state.tasks[col.indices[row]];
+					const selected = active && row === boardIdx;
+					const icon = statusIcon(item.status);
+					const text = truncateToWidth(` ${icon} ${item.text}`, colWidth - 1);
+					if (selected) {
+						rowLine += `\x1b[7m${padVisible(text, colWidth)}\x1b[0m`;
+					} else {
+						rowLine += padVisible(text, colWidth);
+					}
+				} else {
+					rowLine += padVisible("", colWidth);
+				}
+			}
+			lines.push(truncateToWidth(rowLine, width));
+		}
+	}
+}
+
+/**
+ * Factory function for ctx.ui.custom() integration.
+ * Returns a render function compatible with pi-tui's custom overlay API.
  */
 export function renderKanboardOverlay(params?: {
-  docsRoot?: string;
-  onComplete?: () => void;
+	docsRoot?: string;
+	onComplete?: () => void;
 }) {
-  return (
-    tui: any,
-    theme: any,
-    _kb: any,
-    done: (result: { viewed: boolean } | null) => void,
-  ) => {
-    const state: KanboardState = {
-      tab: "tasks",
-      tasks: [],
-      taskIndex: 0,
-      taskScroll: 0,
-      boardColumns: { todo: [], inProgress: [], done: [] },
-      boardCol: 0,
-      boardIndex: [0, 0, 0],
-      pendingG: false,
-      docsRoot: params?.docsRoot ?? ".unipi/docs",
-    };
-
-    // Load data
-    let loaded = false;
-    const ensureLoaded = async () => {
-      if (loaded) return;
-      const registry = await createDefaultRegistry();
-      const docs = registry.parseAll(state.docsRoot);
-      state.tasks = docs.flatMap((d) => d.items);
-
-      // Build board columns
-      state.boardColumns = { todo: [], inProgress: [], done: [] };
-      state.tasks.forEach((item, idx) => {
-        if (item.status === "done") state.boardColumns.done.push(idx);
-        else if (item.status === "in-progress") state.boardColumns.inProgress.push(idx);
-        else state.boardColumns.todo.push(idx);
-      });
-
-      // Init board indices
-      state.boardIndex = [
-        0,
-        0,
-        0,
-      ];
-
-      loaded = true;
-    };
-
-    const render = async () => {
-      await ensureLoaded();
-
-      const width = tui.width;
-      const height = tui.height;
-      const lines: string[] = [];
-
-      // Header
-      const header = " 📋 Kanboard ";
-      const tabLine =
-        "  [T]asks  |  [B]oard  ".replace(
-          state.tab === "tasks" ? "[T]" : "T",
-          state.tab === "tasks" ? "▸T" : " T",
-        ).replace(
-          state.tab === "board" ? "[B]" : "B",
-          state.tab === "board" ? "▸B" : " B",
-        );
-      lines.push(truncateToWidth(header, width));
-      lines.push(truncateToWidth(tabLine, width));
-      lines.push("─".repeat(width));
-
-      if (state.tab === "tasks") {
-        renderTasksTab(lines, width, height - 5);
-      } else {
-        renderBoardTab(lines, width, height - 5);
-      }
-
-      // Footer
-      lines.push("─".repeat(width));
-      const footer = " j/k: navigate  Tab: switch tab  q/Esc: close ";
-      lines.push(truncateToWidth(footer, width));
-
-      tui.setContent(lines);
-    };
-
-    const renderTasksTab = (lines: string[], width: number, maxLines: number) => {
-      if (state.tasks.length === 0) {
-        lines.push(truncateToWidth("  No tasks found.", width));
-        return;
-      }
-
-      // Ensure index in range
-      state.taskIndex = Math.min(state.taskIndex, state.tasks.length - 1);
-      state.taskIndex = Math.max(0, state.taskIndex);
-
-      // Scroll to keep selected visible
-      if (state.taskIndex < state.taskScroll) state.taskScroll = state.taskIndex;
-      if (state.taskIndex >= state.taskScroll + maxLines) {
-        state.taskScroll = state.taskIndex - maxLines + 1;
-      }
-
-      const visible = state.tasks.slice(
-        state.taskScroll,
-        state.taskScroll + maxLines,
-      );
-
-      for (let i = 0; i < visible.length; i++) {
-        const item = visible[i];
-        const globalIdx = state.taskScroll + i;
-        const selected = globalIdx === state.taskIndex;
-        const prefix = selected ? " ▸ " : "   ";
-        const icon = statusIcon(item.status);
-        const source = `[${item.sourceFile}]`;
-        const line = `${prefix}${icon} ${item.text}  ${source}`;
-        lines.push(
-          truncateToWidth(
-            selected ? `\x1b[7m${padVisible(line, width)}\x1b[0m` : line,
-            width,
-          ),
-        );
-      }
-    };
-
-    const renderBoardTab = (lines: string[], width: number, maxLines: number) => {
-      const colWidth = Math.floor(width / 3);
-      const cols: Array<{ title: string; indices: number[]; colIdx: number }> = [
-        { title: "To Do", indices: state.boardColumns.todo, colIdx: 0 },
-        { title: "In Progress", indices: state.boardColumns.inProgress, colIdx: 1 },
-        { title: "Done", indices: state.boardColumns.done, colIdx: 2 },
-      ];
-
-      // Column headers
-      let headerLine = "";
-      for (const col of cols) {
-        const isActive = col.colIdx === state.boardCol;
-        const title = isActive ? `▸ ${col.title}` : `  ${col.title}`;
-        headerLine += padVisible(` ${title} (${col.indices.length})`, colWidth);
-      }
-      lines.push(truncateToWidth(headerLine, width));
-      lines.push("─".repeat(width));
-
-      // Column items
-      const maxItems = Math.max(
-        ...cols.map((c) => c.indices.length),
-        maxLines - 2,
-      );
-      for (let row = 0; row < Math.min(maxItems, maxLines - 2); row++) {
-        let rowLine = "";
-        for (const col of cols) {
-          const active = col.colIdx === state.boardCol;
-          const boardIdx = state.boardIndex[col.colIdx] ?? 0;
-          if (row < col.indices.length) {
-            const item = state.tasks[col.indices[row]];
-            const selected = active && row === boardIdx;
-            const icon = statusIcon(item.status);
-            const text = truncateToWidth(` ${icon} ${item.text}`, colWidth - 1);
-            if (selected) {
-              rowLine += `\x1b[7m${padVisible(text, colWidth)}\x1b[0m`;
-            } else {
-              rowLine += padVisible(text, colWidth);
-            }
-          } else {
-            rowLine += padVisible("", colWidth);
-          }
-        }
-        lines.push(truncateToWidth(rowLine, width));
-      }
-    };
-
-    const handleKey = async (key: any) => {
-      await ensureLoaded();
-
-      // Close
-      if (matchesKey(key, "q") || matchesKey(key, "escape")) {
-        done({ viewed: true });
-        return;
-      }
-
-      // Tab switching
-      if (matchesKey(key, "tab") || matchesKey(key, "b")) {
-        state.tab = state.tab === "tasks" ? "board" : "tasks";
-        render();
-        return;
-      }
-
-      if (matchesKey(key, "t")) {
-        state.tab = "tasks";
-        render();
-        return;
-      }
-
-      // Navigation
-      if (state.tab === "tasks") {
-        if (matchesKey(key, "j") || matchesKey(key, "down")) {
-          state.taskIndex = Math.min(state.taskIndex + 1, state.tasks.length - 1);
-        } else if (matchesKey(key, "k") || matchesKey(key, "up")) {
-          state.taskIndex = Math.max(state.taskIndex - 1, 0);
-        } else if (matchesKey(key, "g")) {
-          if (state.pendingG) {
-            state.taskIndex = 0;
-            state.pendingG = false;
-          } else {
-            state.pendingG = true;
-            setTimeout(() => {
-              state.pendingG = false;
-            }, 500);
-          }
-        } else if (matchesKey(key, "shift+g")) {
-          state.taskIndex = state.tasks.length - 1;
-        }
-      } else {
-        // Board navigation
-        const cols = [
-          state.boardColumns.todo,
-          state.boardColumns.inProgress,
-          state.boardColumns.done,
-        ];
-
-        if (matchesKey(key, "h") || matchesKey(key, "left")) {
-          state.boardCol = Math.max(0, state.boardCol - 1);
-        } else if (matchesKey(key, "l") || matchesKey(key, "right")) {
-          state.boardCol = Math.min(2, state.boardCol + 1);
-        } else if (matchesKey(key, "j") || matchesKey(key, "down")) {
-          const col = cols[state.boardCol];
-          state.boardIndex[state.boardCol] = Math.min(
-            state.boardIndex[state.boardCol] + 1,
-            col.length - 1,
-          );
-        } else if (matchesKey(key, "k") || matchesKey(key, "up")) {
-          state.boardIndex[state.boardCol] = Math.max(
-            state.boardIndex[state.boardCol] - 1,
-            0,
-          );
-        }
-      }
-
-      render();
-    };
-
-    // Start
-    render();
-    tui.on("key", handleKey);
-  };
+	return (tui: any, _theme: any, _kb: any, done: () => void) => {
+		const overlay = new KanboardOverlay({
+			docsRoot: params?.docsRoot,
+			onComplete: () => {
+				done();
+				params?.onComplete?.();
+			},
+		});
+		overlay.requestRender = () => tui.requestRender();
+		return {
+			render: (w: number) => overlay.render(w),
+			invalidate: () => overlay.invalidate(),
+			handleInput: (data: string) => {
+				overlay.handleInput(data);
+			},
+		};
+	};
 }


### PR DESCRIPTION
## Summary

Two fixes for the kanboard and info-screen TUI overlays:

1. **Kanboard TUI overlay was dead code** — `renderKanboardOverlay` was imported but never called, and when called it used the deprecated `tui.setContent()`/`tui.on("key")` API that is incompatible with pi-tui 0.70.5.
2. **Info-screen keyboard input broke under Kitty protocol** — `handleInput` used raw escape sequence string comparisons (`\x1b[C`, etc.) that only match legacy terminal encoding. Kitty keyboard protocol sends different sequences.

## Environment

| Component | Version |
|-----------|---------|
| pi coding agent | **0.70.5** |
| Node.js | v24.14.0 |
| @pi-unipi/unipi | npm (filtered: compactor ext, worktree-create skill) |
| Terminal | Kitty (keyboard protocol enabled) |

### Installed pi packages

```json
"npm:@pi-unipi/unipi" (compactor + worktree-create skill)
"npm:pi-llm-debugging", "npm:pi-lens", "npm:pi-extmgr",
"npm:pi-sessions", "npm:pi-context-zone", ...
```

## Changes

### `packages/kanboard/tui/kanboard-overlay.ts`
**Root cause:** `renderKanboardOverlay` used deprecated `tui.setContent()` / `tui.on("key")` pattern. pi-tui 0.70.5 routes keyboard input through the `Component` interface (`{ render(width), handleInput(data) }`). The old `tui.on()` pattern is not wired to overlay focus, so keypresses were silently dropped.

**Fix:** Rewrote to a `KanboardOverlay` class implementing the Component interface. Keyboard handling now uses `matchesKey()` from `@mariozechner/pi-tui`. Factory function exports `{ render, handleInput, invalidate }` for `ctx.ui.custom()` integration.

### `packages/kanboard/commands.ts`
**Root cause:** `renderKanboardOverlay` was imported (line 12) but **never called** — the `/unipi:kanboard` command only toggled an HTTP server. The overlay was unreachable dead code.

**Fix:** Replaced the server-toggle handler with `ctx.ui.custom(renderKanboardOverlay({...}), { overlay: true })`. Removed dead server imports, PID file logic, and unused module variables.

### `packages/info-screen/tui/info-overlay.ts`
**Root cause:** `handleInput()` used raw escape sequence comparisons (`\x1b[C` for right arrow, `\x1b` for escape). Under Kitty keyboard protocol, these sequences differ — e.g., right arrow sends `\x1b[1;5C` with modifiers, not `\x1b[C`. All arrow/escape keys stopped responding.

**Fix:** Replaced raw string comparisons with `matchesKey(data, "right"/"left"/"up"/"down"/"escape")` from `@mariozechner/pi-tui`, which handles both legacy and Kitty protocols correctly. Plain ASCII keys (h/j/k/l/q) kept as literal comparisons.

## Verification

```bash
cd /path/to/unipi && pi --no-extensions -e .
```

| Command | Test |
|---------|------|
| `/unipi:kanboard` | TUI overlay opens; j/k navigate items; h/l/tab switch tabs/columns; q closes |
| `/unipi:info` | Dashboard opens; arrow keys navigate tabs; j/k scroll; q closes |

Both overlays now respond to keyboard input under Kitty protocol.