### PR TITLE
feat(notify): add suppressWhenFocused for native notifications

### DIFF
--- a/packages/core/events.ts
+++ b/packages/core/events.ts
@@ -409,6 +409,8 @@ export interface UnipiNotificationSentEvent {
   platforms: string[];
   /** Whether all platforms succeeded */
   success: boolean;
+  /** Platforms where notification was suppressed (e.g. window focused) */
+  suppressedPlatforms?: string[];
   /** ISO timestamp */
   timestamp: string;
 }

--- a/packages/notify/commands.ts
+++ b/packages/notify/commands.ts
@@ -14,7 +14,7 @@ import { NtfySetupOverlay } from "./tui/ntfy-setup.js";
 import { RecapModelSelectorOverlay } from "./tui/recap-model-selector.js";
 import { loadConfig } from "./settings.js";
 import { loadNtfyConfig } from "./ntfy-config.js";
-import { sendNativeNotification } from "./platforms/native.js";
+import { sendNativeNotification, SuppressedError } from "./platforms/native.js";
 import { sendGotifyNotification } from "./platforms/gotify.js";
 import { sendTelegramNotification } from "./platforms/telegram.js";
 import { sendNtfyNotification } from "./platforms/ntfy.js";
@@ -267,12 +267,17 @@ export function registerNotifyCommands(pi: ExtensionAPI): void {
           try {
             await sendNativeNotification(title, message, {
               windowsAppId: config.native.windowsAppId,
+              suppressWhenFocused: config.native.suppressWhenFocused,
             });
             results.push("✓ Native: sent");
           } catch (err) {
-            results.push(
-              `✗ Native: ${err instanceof Error ? err.message : "failed"}`
-            );
+            if (err instanceof SuppressedError) {
+              results.push("— Native: suppressed (window focused)");
+            } else {
+              results.push(
+                `✗ Native: ${err instanceof Error ? err.message : "failed"}`
+              );
+            }
           }
         }
 

--- a/packages/notify/events.ts
+++ b/packages/notify/events.ts
@@ -9,7 +9,7 @@ import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-age
 import { UNIPI_EVENTS, emitEvent } from "@pi-unipi/core";
 import type { NotifyConfig, NotifyPlatform, NotifyDispatchResult } from "./types.js";
 import { loadNtfyConfig } from "./ntfy-config.js";
-import { sendNativeNotification } from "./platforms/native.js";
+import { sendNativeNotification, SuppressedError } from "./platforms/native.js";
 import { sendGotifyNotification } from "./platforms/gotify.js";
 import { sendTelegramNotification } from "./platforms/telegram.js";
 import { sendNtfyNotification } from "./platforms/ntfy.js";
@@ -184,6 +184,10 @@ export async function dispatchNotification(
         await sendToPlatform(platform, title, message, config, cwd);
         return { platform, success: true };
       } catch (err) {
+        // SuppressedError is intentional, not a failure
+        if (err instanceof SuppressedError) {
+          return { platform, success: true, suppressed: true };
+        }
         // Silently ignore — platform send failure is tracked in results.
         return {
           platform,
@@ -194,13 +198,18 @@ export async function dispatchNotification(
     })
   );
 
-  const allSuccess = results.length > 0 && results.every((r) => r.success);
+  const unsuppressed = results.filter((r) => !r.suppressed);
+  const allSuccess = results.length > 0 && unsuppressed.every((r) => r.success);
+  const suppressedPlatforms = results
+    .filter((r) => r.suppressed)
+    .map((r) => r.platform);
 
   // Emit notification sent event
   emitEvent(pi, UNIPI_EVENTS.NOTIFICATION_SENT, {
     eventType,
     platforms: enabledPlatforms,
     success: allSuccess,
+    ...(suppressedPlatforms.length > 0 && { suppressedPlatforms }),
     timestamp: new Date().toISOString(),
   });
 
@@ -219,6 +228,7 @@ async function sendToPlatform(
     case "native":
       await sendNativeNotification(title, message, {
         windowsAppId: config.native.windowsAppId,
+        suppressWhenFocused: config.native.suppressWhenFocused,
       });
       break;
     case "gotify":

--- a/packages/notify/platforms/focus-win.ts
+++ b/packages/notify/platforms/focus-win.ts
@@ -1,0 +1,123 @@
+/**
+ * @pi-unipi/notify — Windows focus detection
+ *
+ * Checks whether the terminal window is the foreground (active) window
+ * by walking the WMI process tree upward from the current process PID
+ * and comparing each ancestor against the foreground window's owner PID.
+ *
+ * This approach works reliably across cmd, PowerShell, and Windows
+ * Terminal, unlike GetConsoleWindow which returns NULL in spawned
+ * child processes.
+ *
+ * Requires PowerShell (built-in on Windows 7+).
+ */
+
+import { execFile } from "child_process";
+import { writeFileSync, rmSync, mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// ---------------------------------------------------------------------------
+// PowerShell script (embedded)
+// ---------------------------------------------------------------------------
+
+const POWERCHECK_SCRIPT = `
+param($targetPid)
+Add-Type @'
+using System;
+using System.Runtime.InteropServices;
+public class WinAPI {
+    [DllImport("user32.dll", SetLastError = false)]
+    public static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll", SetLastError = false)]
+    public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+}
+'@ | Out-Null
+$fgHwnd = [WinAPI]::GetForegroundWindow()
+$fgPid = 0
+[void][WinAPI]::GetWindowThreadProcessId($fgHwnd, [ref]$fgPid)
+$curPid = $targetPid
+$maxDepth = 20
+while ($curPid -gt 0 -and $maxDepth-- -gt 0) {
+    if ($curPid -eq $fgPid) { Write-Host -NoNewline 'True'; exit }
+    $proc = Get-CimInstance -Class Win32_Process -Filter "ProcessId = $curPid" -ErrorAction SilentlyContinue | Select-Object -Property ParentProcessId
+    if (-not $proc) { break }
+    $curPid = $proc.ParentProcessId
+}
+Write-Host -NoNewline 'False'
+`;
+
+// ---------------------------------------------------------------------------
+// Cache — avoid spawning PowerShell on every check
+// ---------------------------------------------------------------------------
+
+let cached: { result: boolean; time: number } | null = null;
+const CACHE_TTL_MS = 500;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the terminal window that owns the current process is
+ * the foreground (active) window on Windows.
+ *
+ * Works by:
+ *   1. Calling Win32 GetForegroundWindow + GetWindowThreadProcessId to
+ *      obtain the foreground window's owning PID.
+ *   2. Walking the WMI Win32_Process parent chain upward from
+ *      process.pid.
+ *   3. If any ancestor PID matches the foreground PID the terminal is
+ *      considered focused.
+ *
+ * The result is cached for 500 ms to avoid spawning PowerShell on rapid
+ * consecutive checks (e.g. batch notifications).
+ */
+export async function isWindowFocusedOnWindows(): Promise<boolean> {
+  const now = Date.now();
+  if (cached && now - cached.time < CACHE_TTL_MS) {
+    return cached.result;
+  }
+
+  let tmpDir: string | null = null;
+  try {
+    tmpDir = mkdtempSync(join(tmpdir(), "pi-focus-"));
+    const scriptPath = join(tmpDir, "check.ps1");
+    writeFileSync(scriptPath, POWERCHECK_SCRIPT, "utf-8");
+
+    const stdout = await new Promise<string>((resolve, reject) => {
+      execFile(
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          scriptPath,
+          String(process.pid),
+        ],
+        { timeout: 5000, encoding: "utf-8" },
+        (err, out) => {
+          if (err) reject(err);
+          else resolve(out);
+        }
+      );
+    });
+
+    cached = { result: stdout.trim() === "True", time: Date.now() };
+    return cached.result;
+  } catch {
+    // Detection failure → safe default: assume NOT focused (don't suppress)
+    cached = { result: false, time: Date.now() };
+    return false;
+  } finally {
+    if (tmpDir) {
+      try {
+        rmSync(tmpDir, { recursive: true });
+      } catch {
+        // Temp file cleanup is non-critical
+      }
+    }
+  }
+}

--- a/packages/notify/platforms/focus.ts
+++ b/packages/notify/platforms/focus.ts
@@ -1,0 +1,33 @@
+/**
+ * @pi-unipi/notify — Focus detection abstraction
+ *
+ * Unified interface for checking whether the terminal window is the
+ * foreground (active) window. Platform-specific implementations are
+ * dispatched based on process.platform.
+ *
+ * Currently implemented:
+ *   - Windows (win32): calls focus-win.ts
+ *
+ * Unimplemented platforms always return false (no suppression).
+ */
+
+import { isWindowFocusedOnWindows } from "./focus-win.js";
+
+/**
+ * Check whether the current terminal/console window is the foreground
+ * (active) window. Used by sendNativeNotification to optionally
+ * suppress notifications when the user is already looking at the screen.
+ *
+ * @returns true if the terminal is the foreground window, false otherwise.
+ *          On unimplemented platforms, always returns false.
+ */
+export async function isWindowFocused(): Promise<boolean> {
+  switch (process.platform) {
+    case "win32":
+      return await isWindowFocusedOnWindows();
+    // TODO: macOS — use osascript to check frontmost application
+    // TODO: Linux — use xdotool (X11) or per-compositor tool (Wayland)
+    default:
+      return false;
+  }
+}

--- a/packages/notify/platforms/native.ts
+++ b/packages/notify/platforms/native.ts
@@ -8,22 +8,54 @@
  */
 
 import notifier from "node-notifier";
+import { isWindowFocused } from "./focus.js";
 
 /** Options for native notification */
 export interface NativeNotificationOptions {
   /** Windows appID to show instead of "SnoreToast" */
   windowsAppId?: string;
+  /**
+   * When true, suppresses the notification if the terminal window is
+   * the foreground (active) window. Only effective on platforms where
+   * `isWindowFocused` is implemented (currently Windows).
+   */
+  suppressWhenFocused?: boolean;
+}
+
+/**
+ * Thrown by sendNativeNotification when the notification was suppressed
+ * because suppressWhenFocused is set and the terminal window is focused.
+ *
+ * Callers should catch this and treat it as intentional suppression,
+ * NOT as a send failure.
+ */
+export class SuppressedError extends Error {
+  constructor() {
+    super("Notification suppressed: terminal window is focused");
+    this.name = "SuppressedError";
+  }
 }
 
 /**
  * Send a native OS notification.
- * Resolves when notification is shown, rejects on error.
+ *
+ * When `suppressWhenFocused` is true and `isWindowFocused()` returns true
+ * (i.e. the terminal is the foreground window), the notification is
+ * suppressed and the promise rejects with SuppressedError.
+ *
+ * Resolves when notification is shown, rejects with SuppressedError on
+ * suppression or with a standard Error on failure.
  */
 export async function sendNativeNotification(
   title: string,
   message: string,
   options?: NativeNotificationOptions
 ): Promise<void> {
+  // Suppress if the terminal window is currently focused
+  if (options?.suppressWhenFocused && await isWindowFocused()) {
+    throw new SuppressedError();
+  }
+
   return new Promise((resolve, reject) => {
     notifier.notify(
       {

--- a/packages/notify/settings.ts
+++ b/packages/notify/settings.ts
@@ -30,6 +30,7 @@ export const DEFAULT_CONFIG: NotifyConfig = {
   },
   native: {
     enabled: true,
+    suppressWhenFocused: false,
   },
   gotify: {
     enabled: false,

--- a/packages/notify/tui/settings-overlay.ts
+++ b/packages/notify/tui/settings-overlay.ts
@@ -85,7 +85,7 @@ export class NotifySettingsOverlay implements Component {
   }
 
   private get maxItems(): number {
-    if (this.section === "platforms") return 4; // native, gotify, telegram, ntfy
+    if (this.section === "platforms") return 5; // native, gotify, telegram, ntfy + suppress option
     if (this.section === "recap") return 1; // toggle
     return Object.keys(this.config.events).length;
   }
@@ -98,12 +98,17 @@ export class NotifySettingsOverlay implements Component {
         "telegram",
         "ntfy",
       ];
-      const key = platforms[this.selectedIndex];
-      if (key === "ntfy") {
-        // ntfy toggle updates the resolved ntfy config
-        this.ntfyConfig.enabled = !this.ntfyConfig.enabled;
-      } else if (key) {
-        this.config[key].enabled = !this.config[key].enabled;
+      if (this.selectedIndex < platforms.length) {
+        const key = platforms[this.selectedIndex];
+        if (key === "ntfy") {
+          // ntfy toggle updates the resolved ntfy config
+          this.ntfyConfig.enabled = !this.ntfyConfig.enabled;
+        } else if (key) {
+          this.config[key].enabled = !this.config[key].enabled;
+        }
+      } else {
+        // suppressWhenFocused toggle (index 4)
+        this.config.native.suppressWhenFocused = !this.config.native.suppressWhenFocused;
       }
     } else if (this.section === "recap") {
       this.config.recap.enabled = !this.config.recap.enabled;
@@ -269,6 +274,27 @@ export class NotifySettingsOverlay implements Component {
       lines.push(
         this.frameLine(
           `${isSelected ? this.fg("accent", "▸") : " "} ${toggle} ${label}  ${this.fg("dim", p.detail)}`,
+          innerWidth
+        )
+      );
+    }
+
+    // suppressWhenFocused toggle (index 4)
+    {
+      const i = platforms.length;
+      const isSelected = i === this.selectedIndex;
+      const isEnabled = this.config.native.suppressWhenFocused === true;
+      const toggleOn = this.fg("success", "●");
+      const toggleOff = this.fg("dim", "○");
+      const toggle = isEnabled ? toggleOn : toggleOff;
+      const label = isSelected
+        ? this.bold("Suppress when focused")
+        : this.fg("dim", "Suppress when focused");
+      const detail = this.fg("dim", isEnabled ? "Windows only — terminal in foreground → skip" : "Windows only");
+
+      lines.push(
+        this.frameLine(
+          `${isSelected ? this.fg("accent", "▸") : " "} ${toggle} ${label}  ${detail}`,
           innerWidth
         )
       );

--- a/packages/notify/types.ts
+++ b/packages/notify/types.ts
@@ -19,6 +19,12 @@ export interface NativeConfig {
   enabled: boolean;
   /** Windows appID to show instead of "SnoreToast" */
   windowsAppId?: string;
+  /**
+   * When true, suppresses the notification if the terminal window is the
+   * foreground (active) window. Only effective on supported platforms
+   * (currently Windows). Default: false.
+   */
+  suppressWhenFocused?: boolean;
 }
 
 /** Gotify notification platform config */
@@ -101,6 +107,8 @@ export interface NotifyResult {
   platform: NotifyPlatform;
   /** Whether the send succeeded */
   success: boolean;
+  /** True when the notification was intentionally suppressed (e.g. window focused) */
+  suppressed?: boolean;
   /** Error message if failed */
   error?: string;
 }


### PR DESCRIPTION
Closes #5

Adds `native.suppressWhenFocused` — when enabled, desktop notifications are skipped if the terminal window is in the foreground.

**Windows**: foreground PID via Win32 API → WMI process tree walk from `process.pid`. Async (`execFile`) to avoid blocking.

**macOS / Linux**: not implemented — `isWindowFocused()` returns `false`.

Default `false`, backward compatible.