### PR TITLE
fix: improve unipi command display and terminal color  fallback

### DIFF
--- a/.unipi/docs/debug/2026-05-19-mac-footer-category-colors-debug.md
+++ b/.unipi/docs/debug/2026-05-19-mac-footer-category-colors-debug.md
@@ -1,0 +1,142 @@
+---
+title: "Footer category colors do not appear on macOS terminals — Debug Report"
+type: debug
+date: 2026-05-19
+severity: medium
+status: root-caused
+---
+
+# Footer category colors do not appear on macOS terminals — Debug Report
+
+## Summary
+`@pi-unipi/footer` colour-codes the workflow segment by category (brainstorm = red, plan = orange, work = yellow, review = green, etc.). On macOS — both in Apple Terminal.app and inside the “Unipi agent” terminal (Claude Code / Cursor / Zed agent transcript) — those colours are not visible: the footer renders as plain (or default-fg) text and the category distinction is lost.
+
+## Expected Behavior
+The current_command footer segment renders each workflow category in its own colour, as defined in `packages/footer/src/rendering/theme.ts`:
+
+| Category                                  | Semantic color        | Hex      |
+| ----------------------------------------- | --------------------- | -------- |
+| brainstorm / debug / gather-context / quick-* / chore-create | `workflowBrainstorm` | `#e06c75` (red)    |
+| plan / chore-execute                      | `workflowChoreExec`   | `#d19a66` (orange) |
+| work                                      | `workflowWork`        | `#e5c07b` (yellow) |
+| review / review-work                      | `workflowReview`      | `#82cc6f` (green)  |
+| auto                                      | `workflowAuto`        | `#c792ea` (purple) |
+| worktree-*                                | `worktree`            | `#61afef` (blue)   |
+| (idle)                                    | `workflowNone`        | `#4a6a7a` (muted)  |
+
+(Confirmed in `packages/footer/src/segments/workflow.ts:24-60` and `packages/footer/src/rendering/theme.ts:18-66`.)
+
+## Actual Behavior
+- In Apple Terminal.app: the workflow segment shows text with no colour difference between categories (often plain default-fg, or with only the icon coloured by theme).
+- In the agent terminal (Claude Code / Cursor / etc.) on macOS: the rendered footer also shows no category colour; the ANSI escape bytes are stripped/printed literally by the agent’s transcript renderer.
+- Other coloured footer segments that use a hex value (model, session, ralph, kanboard, …) suffer the same problem in the same environments.
+
+## Reproduction Steps
+1. Open `Terminal.app` (the default macOS terminal) on macOS 13+ / 14+ / 15+.
+2. Run a unipi-enabled pi-coding-agent session (or simulate by emitting the same escapes):
+   ```bash
+   printf 'truecolor: \x1b[38;2;224;108;117mBRAINSTORM\x1b[0m\n'
+   printf '256-color : \x1b[38;5;203mBRAINSTORM\x1b[0m\n'
+   ```
+   - `truecolor` line appears uncoloured (Apple Terminal silently drops `\e[38;2;…m`).
+   - `256-color` line renders correctly in red — proving the terminal does support ANSI colour, just not 24-bit.
+3. Trigger a workflow command (e.g. `/unipi:work`) and observe the footer’s `current_command` segment: no red/orange/green differentiation.
+
+For the agent transcript case:
+1. Run the same agent on any macOS terminal.
+2. Inspect the agent UI’s rendering of a tool result containing ANSI escapes — the bytes are shown literally (e.g. `[38;2;231;108;117mHELLO[0m`) or stripped entirely.
+
+## Environment
+- macOS (Darwin 25.x — Sonoma / Sequoia / Tahoe).
+- Apple Terminal.app — `TERM=xterm-256color`, `TERM_PROGRAM=Apple_Terminal`, `COLORTERM` **unset**.
+- iTerm2 / WezTerm / Ghostty / Alacritty / Zed integrated terminal — `COLORTERM=truecolor` (these DO render correctly; verified in the current Zed terminal: `COLORTERM=truecolor`, `TERM_PROGRAM=zed`).
+- “Unipi agent” terminal: pty wrapped by Claude Code / Cursor; the user-facing transcript view does not interpret ANSI escapes for tool output.
+
+## Root Cause Analysis
+
+### Failure Chain
+1. Workflow segment computes a semantic colour via `getWorkflowSemanticColor(command)` → `applyColor(semantic, …)` in `packages/footer/src/segments/workflow.ts:82`.
+2. `applyColor` looks up the colour value and — because every workflow category value is a hex string like `#e06c75` — takes the **hex branch** in `packages/footer/src/rendering/theme.ts:113-121`:
+   ```ts
+   if (colorValue.startsWith("#")) {
+     // Hex color — we need to emit ANSI directly
+     const r = parseInt(hex.slice(0, 2), 16);
+     const g = parseInt(hex.slice(2, 4), 16);
+     const b = parseInt(hex.slice(4, 6), 16);
+     return `\x1b[38;2;${r};${g};${b}m${text}\x1b[0m`;
+   }
+   ```
+3. The renderer pushes the resulting string into pi’s `setFooter(...)` (see `packages/footer/src/index.ts:152`).
+4. The escape sequence emitted is **24-bit truecolor** (`CSI 38;2;R;G;B m`).
+5. The terminal receiving that sequence on macOS is one of:
+   - **Apple Terminal.app** — does not support 24-bit truecolor (long-standing limitation, still true on macOS 26). It silently swallows `\e[38;2;…m`, leaving text uncoloured.
+   - **An agent UI’s tool-output panel** — strips or literalises ANSI; never displays colour for tool stdout regardless of terminal capability.
+6. Result: every category prints with the **same** appearance — no visual differentiation.
+
+### Root Cause
+The footer renderer hard-codes **24-bit truecolor** escape sequences for every hex semantic color, with **no capability check**. It does not fall back to 256-colour (`\e[38;5;Nm`) when the terminal lacks truecolor support, and it does not consult the capability detector that already exists in `@pi-unipi/utility`.
+
+A secondary defect compounds this: `packages/utility/src/display/capabilities.ts:46-62` declares `xterm-256color`, `screen-256color`, and `tmux-256color` as “truecolor terms” — those terminfo names indicate **256-colour**, not truecolor. Even if the footer started consulting `detectColorSupport()`, Apple Terminal.app (which exports `TERM=xterm-256color`) would be misclassified as truecolor-capable and the bug would persist. The list also lacks the well-known opt-out: an explicit check that `TERM_PROGRAM === "Apple_Terminal"` should force `truecolor: false`.
+
+### Evidence
+- `packages/footer/src/rendering/theme.ts:101-126` — `applyColor()` unconditionally emits `\x1b[38;2;R;G;Bm` for any hex value. No `if (truecolor)` gate, no fallback path.
+- `packages/footer/src/rendering/theme.ts:18-66` — every workflow / status hex (`#c792ea`, `#e06c75`, `#d19a66`, `#e5c07b`, `#82cc6f`, `#61afef`, `#4a6a7a`) routes through that branch.
+- `packages/footer/src/segments/workflow.ts:75,82,90,108` — every workflow segment call site uses `applyColor`, so all of them are affected.
+- `packages/footer/src/segments/{mcp,notify,core,kanboard,…}.ts` — same pattern; all coloured segments share the bug.
+- `packages/utility/src/display/capabilities.ts:46-62` — truecolor allow-list incorrectly includes 256-colour terminfo names and is missing an Apple_Terminal opt-out.
+- `packages/utility/src/display/capabilities.ts` is never imported by `packages/footer/**` — verified by `grep -rn "capabilities\|detectColorSupport\|detectCapabilities" packages/footer/`.
+- Live env probe (Zed terminal, current session): `COLORTERM=truecolor`, `TERM=xterm-256color`, `TERM_PROGRAM=zed` — Zed renders correctly, which is consistent with “truecolor works only when the terminal advertises it”.
+
+## Affected Files
+- `packages/footer/src/rendering/theme.ts` — `applyColor()` always emits 24-bit codes for hex.
+- `packages/footer/src/segments/workflow.ts` — primary symptom site (the user-visible category colouring).
+- `packages/footer/src/segments/{mcp,notify,core,kanboard,memory,context,ralph,…}.ts` — same bug class.
+- `packages/utility/src/display/capabilities.ts` — buggy truecolor detector, not wired into the footer.
+
+## Suggested Fix
+High-level approach — gate truecolor emission on detected capability, with a clean 256-colour fallback.
+
+### Fix Strategy
+1. **Make `applyColor` capability-aware** (`packages/footer/src/rendering/theme.ts`):
+   - Cache a `colorMode = "truecolor" | "256" | "none"` once per process (or per render tick) via `detectCapabilities()` from `@pi-unipi/utility`, with explicit overrides honoured (`NO_COLOR`, `FORCE_COLOR`, and a new footer setting `footer.colorMode`).
+   - For hex values:
+     - `truecolor` → emit `\x1b[38;2;R;G;Bm` (today’s behaviour).
+     - `256` → map to nearest xterm-256 index (a small lookup or the standard cube/grayscale formula) and emit `\x1b[38;5;Nm`.
+     - `none` → return plain text.
+2. **Fix `detectColorSupport`** (`packages/utility/src/display/capabilities.ts`):
+   - Remove `xterm-256color`, `screen-256color`, `tmux-256color` from the truecolor list — those imply only 256-colour.
+   - Add explicit `Apple_Terminal` opt-out: if `TERM_PROGRAM === "Apple_Terminal"` → `truecolor: false` (even if some pty has `COLORTERM=truecolor` leaked in by error).
+   - Require either `COLORTERM in {truecolor, 24bit}` or a known-good `TERM_PROGRAM` (`iTerm.app`, `WezTerm`, `Alacritty`, `kitty`, `ghostty`, `vscode`, `zed`, `cursor`, `Warp`) before reporting `truecolor: true`.
+3. **Surface the colour mode in footer settings** (`packages/footer/src/config.ts` + `tui/settings-tui.ts`):
+   - Add `colorMode: "auto" | "truecolor" | "256" | "none"` with default `auto`.
+   - Allow user override so people on Apple Terminal can force `256` (or anyone can force `none`).
+4. **Document** the macOS Apple Terminal limitation in `packages/footer/README.md` so users know to use iTerm2/WezTerm/Ghostty/etc. or enable `colorMode=256`.
+5. **(Out-of-scope but worth noting)** The agent transcript (Claude Code / Cursor) strips ANSI from tool output by design. The footer fix will restore colours in the real terminal pty hosting the agent, but the agent’s in-app log view is not the footer’s concern — flag this in the user-facing message.
+
+### Risk Assessment
+- **Risk:** Nearest-256 mapping shifts brand colours slightly on 256-colour terminals. **Mitigation:** Pick palette colours that already have good 256 neighbours; allow per-semantic override via `ColorScheme`.
+- **Risk:** Misclassifying an obscure terminal as non-truecolor (downgrade-from-correct). **Mitigation:** `auto` defaults are conservative; users can override via `FORCE_COLOR=3` or `footer.colorMode=truecolor`.
+- **Risk:** Removing names from the truecolor list could regress users who relied on the incorrect heuristic. **Mitigation:** Still treat any `COLORTERM=truecolor` as truecolor — which is what most well-configured truecolor terminals already export.
+
+## Verification Plan
+1. **Unit tests** (`packages/footer/tests/`):
+   - New test: with `COLORTERM` unset and `TERM=xterm-256color`, `applyColor("workflowBrainstorm", "x", …)` emits `\x1b[38;5;Nm` (256), not `\x1b[38;2;…m`.
+   - New test: with `COLORTERM=truecolor`, emits `\x1b[38;2;224;108;117m`.
+   - New test: with `NO_COLOR=1`, emits no escape.
+   - Capability test: `TERM_PROGRAM=Apple_Terminal` ⇒ `truecolor === false` regardless of `TERM`.
+2. **Manual checks**:
+   - Apple Terminal.app on macOS → run unipi; confirm distinct category colours via 256-colour fallback.
+   - iTerm2 / WezTerm / Ghostty → unchanged (still truecolor).
+   - `NO_COLOR=1` → no escapes; plain text.
+   - `FORCE_COLOR=3` inside Apple Terminal → truecolor escapes emitted (user-forced — accepted even if visually they don’t render; documents the override).
+3. **Regression**:
+   - Run `packages/footer/tests/segments.test.ts` and `config.test.ts`.
+   - Visually compare the secondary-row layout: ANSI byte count differs between modes, so check `visibleWidth` accounting still produces correct truncation/zone math.
+
+## Related Issues
+- macOS Apple Terminal.app 24-bit colour: known and ongoing limitation; tracked widely in the dev tooling community (no upstream fix).
+- Many TUI libraries (chalk, ansi-colors, etc.) already implement this exact downgrade — reference their lookup tables for the nearest-256 mapping.
+
+## Notes
+- Today’s capability detector exists but is **dead code** for the footer; wiring it in (and fixing the false positives) is the cheapest reliable fix.
+- The agent terminal’s in-app log/transcript view is a separate concern (it strips ANSI for safety). The fix above resolves the host-terminal case, which is what most users see when they `cd` into the project and run `pi` directly. For the agent in-app view, the most we can do is make sure the footer is **also** legible without colour (e.g., short labels like `WRK`/`REV`/`PLAN`), which the footer already supports via the “labeled” mode.

--- a/packages/autocomplete/src/provider.ts
+++ b/packages/autocomplete/src/provider.ts
@@ -44,6 +44,18 @@ function fuzzyMatch(text: string, query: string): boolean {
 // ─── Namespace detection ─────────────────────────────────────────────
 
 /**
+ * Pi prefixes extension command descriptions with source tags such as
+ * `[u:npm:@pi-unipi/unipi]`. The enchanted provider replaces that with
+ * package tags (`[workflow]`, `[memory]`, …), so strip the source tag from
+ * base descriptions before reusing them.
+ */
+function stripPiSourceTag(description: string): string {
+  return description
+    .replace(/^\[(?:[upt])(?::[^\]]+)?\]\s*/, "")
+    .trimStart();
+}
+
+/**
  * If the query looks like a package namespace (e.g. "workflow", "memory",
  * "utility"), return that package name so its commands sort to the top.
  * Returns null when the query isn't a pure namespace search.
@@ -174,7 +186,7 @@ function getEnhancedUnipiItems(
 
     return {
       value: cmd,
-      label: cmd.replace("unipi:", ""),
+      label: cmd,
       description: desc ? `${tag} ${desc}` : tag,
     };
   });
@@ -261,7 +273,10 @@ export function createEnchantedProvider(
         for (const item of baseSuggestions.items) {
           if (item.value.startsWith("unipi:")) {
             if (item.description) {
-              descriptionOverrides.set(item.value, item.description);
+              const cleanDescription = stripPiSourceTag(item.description);
+              if (cleanDescription) {
+                descriptionOverrides.set(item.value, cleanDescription);
+              }
             }
           } else {
             nonUnipiItems.push(item);

--- a/packages/footer/src/config.ts
+++ b/packages/footer/src/config.ts
@@ -8,7 +8,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import type { FooterSettings, FooterGroupSettings, SeparatorStyle, IconStyle } from "./types.js";
+import type { FooterSettings, FooterGroupSettings, SeparatorStyle, IconStyle, ColorMode } from "./types.js";
 import { UNIPI_SETTINGS_KEY } from "@pi-unipi/core";
 
 /** Default footer settings */
@@ -19,6 +19,7 @@ export const DEFAULT_FOOTER_SETTINGS: FooterSettings = {
   iconStyle: "nerd",
   zoneSeparator: "\u2502", // │
   showFullLabels: false,
+  colorMode: "auto",
   groups: {
     core: { show: true, segments: {} },
     compactor: { show: true, segments: {} },
@@ -96,6 +97,7 @@ export function loadFooterSettings(): FooterSettings {
       iconStyle: isValidIconStyle(footer.iconStyle) ? footer.iconStyle as IconStyle : DEFAULT_FOOTER_SETTINGS.iconStyle,
       zoneSeparator: typeof footer.zoneSeparator === "string" ? footer.zoneSeparator : DEFAULT_FOOTER_SETTINGS.zoneSeparator,
       showFullLabels: typeof footer.showFullLabels === "boolean" ? footer.showFullLabels : DEFAULT_FOOTER_SETTINGS.showFullLabels,
+      colorMode: isValidColorMode(footer.colorMode) ? footer.colorMode as ColorMode : DEFAULT_FOOTER_SETTINGS.colorMode,
       groups: mergeGroupSettings(
         DEFAULT_FOOTER_SETTINGS.groups,
         footer.groups as Record<string, FooterGroupSettings> | undefined,
@@ -167,6 +169,12 @@ function isValidSeparator(value: unknown): boolean {
 function isValidIconStyle(value: unknown): boolean {
   if (typeof value !== "string") return false;
   const valid: string[] = ["nerd", "emoji", "text"];
+  return valid.includes(value);
+}
+
+function isValidColorMode(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  const valid: string[] = ["auto", "truecolor", "256", "none"];
   return valid.includes(value);
 }
 

--- a/packages/footer/src/rendering/renderer.ts
+++ b/packages/footer/src/rendering/renderer.ts
@@ -11,7 +11,7 @@ import type { PresetDef, FooterSegmentContext, FooterSegment, ColorScheme, Rende
 import type { FooterRegistry } from "../registry/index.js";
 import { visibleWidth as piVisibleWidth, truncateToWidth } from "@mariozechner/pi-tui";
 import { getSeparator, separatorVisibleWidth } from "./separators.js";
-import { getDefaultColors } from "./theme.js";
+import { getDefaultColors, setColorMode, refreshColorMode } from "./theme.js";
 import { setIconStyle } from "./icons.js";
 import { getPreset } from "../presets.js";
 import { isSegmentEnabled, isSegmentExplicitlyEnabled, loadFooterSettings } from "../config.js";
@@ -104,6 +104,19 @@ export class FooterRenderer {
   private syncIconStyle(): void {
     const settings = loadFooterSettings();
     setIconStyle(settings.iconStyle);
+    this.syncColorMode(settings);
+  }
+
+  /** Sync the colour-emission mode from settings to the theme module. */
+  private syncColorMode(settings?: ReturnType<typeof loadFooterSettings>): void {
+    const s = settings ?? loadFooterSettings();
+    const mode = s.colorMode ?? "auto";
+    if (mode === "auto") {
+      setColorMode(null);
+      refreshColorMode();
+    } else {
+      setColorMode(mode);
+    }
   }
 
   /** Get the active preset name */

--- a/packages/footer/src/rendering/theme.ts
+++ b/packages/footer/src/rendering/theme.ts
@@ -3,10 +3,173 @@
  *
  * Maps semantic color names to pi theme colors. Supports
  * hex overrides via ColorScheme.
+ *
+ * Color emission is capability-aware: hex values are emitted as 24-bit
+ * truecolor on terminals that advertise truecolor (COLORTERM or known
+ * truecolor TERM_PROGRAM), and gracefully downgraded to the nearest
+ * xterm-256 index on legacy terminals (notably Apple Terminal.app, which
+ * silently swallows 24-bit escapes and renders the text uncoloured).
  */
 
 import type { Theme, ThemeColor } from "@mariozechner/pi-coding-agent";
 import type { ColorScheme, ColorValue, SemanticColor, ThemeLike } from "../types.js";
+
+// ─── Color mode detection ──────────────────────────────────────────────────
+
+/**
+ * Detected colour-emission mode for the current terminal.
+ *  - `truecolor` → emit 24-bit `\x1b[38;2;R;G;Bm`
+ *  - `256`       → emit 8-bit  `\x1b[38;5;Nm` (nearest xterm-256 index)
+ *  - `none`      → emit no colour codes (plain text)
+ */
+export type ColorMode = "truecolor" | "256" | "none";
+
+/** Manual override (set via `setColorMode`) — wins over env-based detection. */
+let manualMode: ColorMode | null = null;
+/** Cached detection result; cleared by `refreshColorMode()`. */
+let detectedMode: ColorMode | null = null;
+
+/** Terminals known to honour 24-bit truecolor escapes. */
+const TRUECOLOR_TERM_PROGRAMS = [
+  "iTerm.app",
+  "WezTerm",
+  "Alacritty",
+  "vscode",
+  "Hyper",
+  "Warp",
+  "ghostty",
+  "Ghostty",
+  "zed",
+  "Zed",
+  "cursor",
+  "Cursor",
+];
+
+/**
+ * Detect the colour mode of the current terminal from environment.
+ * Respects `NO_COLOR`, `FORCE_COLOR`, then sniffs `COLORTERM` / `TERM_PROGRAM`
+ * / `TERM`. Apple Terminal is explicitly capped at 256-colour.
+ */
+function detectColorMode(): ColorMode {
+  const env = process.env;
+  if (env.NO_COLOR || env.NODE_DISABLE_COLORS) return "none";
+  if (env.FORCE_COLOR) {
+    const lvl = parseInt(env.FORCE_COLOR, 10);
+    if (Number.isNaN(lvl)) return "truecolor"; // any non-numeric truthy value
+    if (lvl >= 3) return "truecolor";
+    if (lvl >= 1) return "256";
+    return "none";
+  }
+  const term = env.TERM ?? "";
+  const termProgram = env.TERM_PROGRAM ?? "";
+  // Apple Terminal.app does NOT support 24-bit colour. Force 256 even if
+  // some wrapper leaked COLORTERM into the env.
+  if (termProgram === "Apple_Terminal") {
+    return "256";
+  }
+  if (env.COLORTERM === "truecolor" || env.COLORTERM === "24bit") {
+    return "truecolor";
+  }
+  if (TRUECOLOR_TERM_PROGRAMS.includes(termProgram)) {
+    return "truecolor";
+  }
+  if (term === "dumb") return "none";
+  // Anything that talks ANSI but isn't known-truecolor → 256
+  if (term.includes("256color") || term.includes("color") || term.includes("xterm") || term.includes("ansi") || term.includes("screen") || term.includes("tmux")) {
+    return "256";
+  }
+  // Default conservative: 256 colour. Better than dropping colours entirely
+  // on unknown terminals that almost certainly understand the 256 palette.
+  return "256";
+}
+
+/**
+ * Get the active colour mode (manual override > cached detection > env probe).
+ */
+export function getColorMode(): ColorMode {
+  if (manualMode) return manualMode;
+  if (!detectedMode) detectedMode = detectColorMode();
+  return detectedMode;
+}
+
+/**
+ * Force a specific colour mode (e.g. from user settings). Pass `null` to
+ * revert to auto-detection.
+ */
+export function setColorMode(mode: ColorMode | null): void {
+  manualMode = mode;
+}
+
+/** Re-run env-based detection (useful after settings or env changes). */
+export function refreshColorMode(): ColorMode {
+  detectedMode = null;
+  return getColorMode();
+}
+
+// ─── 24-bit → 256 colour downgrade ─────────────────────────────────────────
+
+/**
+ * Map an RGB triple to the nearest xterm-256 index.
+ *
+ * xterm-256 layout:
+ *   0–15   → system / bright colours (skipped; we route through the cube
+ *            for predictability)
+ *   16–231 → 6×6×6 colour cube
+ *   232–255 → 24-step grayscale
+ *
+ * We pick the better of (cube nearest) and (grayscale nearest) by squared
+ * RGB distance, which matches the heuristic used by chalk / ansi-styles.
+ */
+function rgbTo256(r: number, g: number, b: number): number {
+  // Grayscale candidate
+  const grayAvg = Math.round((r + g + b) / 3);
+  let grayIdx: number;
+  let grayR: number;
+  if (grayAvg < 8) {
+    grayIdx = 16;
+    grayR = 0;
+  } else if (grayAvg > 248) {
+    grayIdx = 231;
+    grayR = 255;
+  } else {
+    const step = Math.round(((grayAvg - 8) / 247) * 24);
+    grayIdx = 232 + step;
+    grayR = 8 + step * 10;
+  }
+  const grayDist = sqDist(r, g, b, grayR, grayR, grayR);
+
+  // Cube candidate (6 steps: 0, 95, 135, 175, 215, 255)
+  const cubeR = cubeStep(r);
+  const cubeG = cubeStep(g);
+  const cubeB = cubeStep(b);
+  const cubeIdx = 16 + 36 * cubeR.idx + 6 * cubeG.idx + cubeB.idx;
+  const cubeDist = sqDist(r, g, b, cubeR.value, cubeG.value, cubeB.value);
+
+  return cubeDist <= grayDist ? cubeIdx : grayIdx;
+}
+
+const CUBE_STEPS = [0, 95, 135, 175, 215, 255];
+function cubeStep(v: number): { idx: number; value: number } {
+  let bestIdx = 0;
+  let bestDist = Infinity;
+  for (let i = 0; i < CUBE_STEPS.length; i++) {
+    const d = Math.abs(v - CUBE_STEPS[i]);
+    if (d < bestDist) {
+      bestDist = d;
+      bestIdx = i;
+    }
+  }
+  return { idx: bestIdx, value: CUBE_STEPS[bestIdx] };
+}
+
+function sqDist(r1: number, g1: number, b1: number, r2: number, g2: number, b2: number): number {
+  const dr = r1 - r2;
+  const dg = g1 - g2;
+  const db = b1 - b2;
+  return dr * dr + dg * dg + db * db;
+}
+
+// ─── Public API ────────────────────────────────────────────────────────────
 
 /** Wrap text in dim ANSI codes for muted placeholder display */
 export function mutedPlaceholder(text: string): string {
@@ -96,6 +259,26 @@ export function resolveColor(color: ColorValue, theme: ThemeLike): string {
 }
 
 /**
+ * Wrap `text` in an ANSI escape for the given hex value, chosen to match
+ * the active colour mode (truecolor / 256 / none).
+ */
+function wrapHex(hex: string, text: string): string {
+  const mode = getColorMode();
+  if (mode === "none") return text;
+  const h = hex.startsWith("#") ? hex.slice(1) : hex;
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return text;
+  if (mode === "truecolor") {
+    return `\x1b[38;2;${r};${g};${b}m${text}\x1b[0m`;
+  }
+  // 256-color fallback
+  const idx = rgbTo256(r, g, b);
+  return `\x1b[38;5;${idx}m${text}\x1b[0m`;
+}
+
+/**
  * Apply a semantic color to text using the theme.
  * Falls back to the default theme color if no override is provided.
  */
@@ -109,16 +292,14 @@ export function applyColor(
   if (!colorValue) {
     // Use default from the map
     const defaultColor = DEFAULT_COLOR_MAP[semantic] || "text";
+    if (typeof defaultColor === "string" && defaultColor.startsWith("#")) {
+      return wrapHex(defaultColor, text);
+    }
     return theme.fg(defaultColor as ThemeColor, text);
   }
 
   if (colorValue.startsWith("#")) {
-    // Hex color — we need to emit ANSI directly
-    const hex = colorValue.slice(1);
-    const r = Number.parseInt(hex.slice(0, 2), 16);
-    const g = Number.parseInt(hex.slice(2, 4), 16);
-    const b = Number.parseInt(hex.slice(4, 6), 16);
-    return `\x1b[38;2;${r};${g};${b}m${text}\x1b[0m`;
+    return wrapHex(colorValue, text);
   }
 
   return theme.fg(colorValue as ThemeColor, text);

--- a/packages/footer/src/types.ts
+++ b/packages/footer/src/types.ts
@@ -82,6 +82,9 @@ export type ColorScheme = Partial<Record<SemanticColor, ColorValue>>;
 /** Icon style — determines which icon set is used for segments */
 export type IconStyle = "nerd" | "emoji" | "text";
 
+/** Colour-emission mode for terminal output. */
+export type ColorMode = "auto" | "truecolor" | "256" | "none";
+
 /** Separator styles for segment dividers */
 export type SeparatorStyle =
   | "powerline"
@@ -190,6 +193,8 @@ export interface FooterSettings {
   zoneSeparator?: string;
   /** Show full labels instead of compact short labels */
   showFullLabels?: boolean;
+  /** Terminal colour mode override (default: "auto" — env-detected). */
+  colorMode?: ColorMode;
   /** Per-group settings */
   groups: Record<string, FooterGroupSettings>;
 }

--- a/packages/footer/tests/theme.test.ts
+++ b/packages/footer/tests/theme.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @pi-unipi/footer — theme color-mode tests
+ *
+ * Covers the macOS Apple-Terminal downgrade and the manual override path.
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  applyColor,
+  getColorMode,
+  setColorMode,
+  refreshColorMode,
+} from "../src/rendering/theme.ts";
+import type { ColorScheme, ThemeLike } from "../src/types.ts";
+
+const fakeTheme: ThemeLike = { fg: (_c, t) => t };
+const colors: ColorScheme = {
+  workflowBrainstorm: "#e06c75",
+  workflowWork: "#e5c07b",
+  workflowReview: "#82cc6f",
+};
+
+function snapshotEnv() {
+  return {
+    NO_COLOR: process.env.NO_COLOR,
+    FORCE_COLOR: process.env.FORCE_COLOR,
+    COLORTERM: process.env.COLORTERM,
+    TERM: process.env.TERM,
+    TERM_PROGRAM: process.env.TERM_PROGRAM,
+    CI: process.env.CI,
+  };
+}
+function restoreEnv(snap: Record<string, string | undefined>) {
+  for (const [k, v] of Object.entries(snap)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+describe("theme color mode", () => {
+  let snap: ReturnType<typeof snapshotEnv>;
+
+  beforeEach(() => {
+    snap = snapshotEnv();
+    setColorMode(null);
+    delete process.env.NO_COLOR;
+    delete process.env.FORCE_COLOR;
+    delete process.env.COLORTERM;
+    delete process.env.TERM_PROGRAM;
+    delete process.env.CI;
+    process.env.TERM = "xterm-256color";
+    refreshColorMode();
+  });
+
+  afterEach(() => {
+    setColorMode(null);
+    restoreEnv(snap);
+    refreshColorMode();
+  });
+
+  it("emits 24-bit truecolor when forced", () => {
+    setColorMode("truecolor");
+    const out = applyColor("workflowBrainstorm", "x", fakeTheme, colors);
+    assert.match(out, /\x1b\[38;2;224;108;117m/);
+  });
+
+  it("emits 8-bit 256-color when forced", () => {
+    setColorMode("256");
+    const out = applyColor("workflowBrainstorm", "x", fakeTheme, colors);
+    assert.match(out, /\x1b\[38;5;\d+m/);
+    assert.doesNotMatch(out, /\x1b\[38;2;/);
+  });
+
+  it("emits no color escapes when forced none", () => {
+    setColorMode("none");
+    const out = applyColor("workflowBrainstorm", "x", fakeTheme, colors);
+    assert.equal(out, "x");
+  });
+
+  it("downgrades to 256 on Apple Terminal even with COLORTERM=truecolor leaked", () => {
+    process.env.TERM_PROGRAM = "Apple_Terminal";
+    process.env.COLORTERM = "truecolor"; // wrapper might leak this
+    refreshColorMode();
+    assert.equal(getColorMode(), "256");
+    const out = applyColor("workflowBrainstorm", "x", fakeTheme, colors);
+    assert.match(out, /\x1b\[38;5;\d+m/);
+    assert.doesNotMatch(out, /\x1b\[38;2;/);
+  });
+
+  it("stays truecolor on iTerm.app + COLORTERM=truecolor", () => {
+    process.env.TERM_PROGRAM = "iTerm.app";
+    process.env.COLORTERM = "truecolor";
+    refreshColorMode();
+    assert.equal(getColorMode(), "truecolor");
+    const out = applyColor("workflowBrainstorm", "x", fakeTheme, colors);
+    assert.match(out, /\x1b\[38;2;224;108;117m/);
+  });
+
+  it("respects NO_COLOR=1", () => {
+    process.env.NO_COLOR = "1";
+    refreshColorMode();
+    assert.equal(getColorMode(), "none");
+    const out = applyColor("workflowBrainstorm", "x", fakeTheme, colors);
+    assert.equal(out, "x");
+  });
+
+  it("FORCE_COLOR=3 overrides Apple_Terminal", () => {
+    process.env.TERM_PROGRAM = "Apple_Terminal";
+    process.env.FORCE_COLOR = "3";
+    refreshColorMode();
+    assert.equal(getColorMode(), "truecolor");
+  });
+
+  it("FORCE_COLOR=1 selects 256 on truecolor terminals", () => {
+    process.env.TERM_PROGRAM = "iTerm.app";
+    process.env.COLORTERM = "truecolor";
+    process.env.FORCE_COLOR = "1";
+    refreshColorMode();
+    assert.equal(getColorMode(), "256");
+  });
+
+  it("treats TERM=dumb as no color", () => {
+    process.env.TERM = "dumb";
+    delete process.env.TERM_PROGRAM;
+    delete process.env.COLORTERM;
+    refreshColorMode();
+    assert.equal(getColorMode(), "none");
+  });
+
+  it("returns plain text for unknown semantic with hex default", () => {
+    setColorMode("256");
+    // Use a known semantic; expect the wrapped 256-colour output
+    const out = applyColor("workflowReview", "ok", fakeTheme, colors);
+    assert.match(out, /\x1b\[38;5;\d+mok\x1b\[0m/);
+  });
+
+  it("maps category hexes to distinct 256 indices (preserves differentiation)", () => {
+    setColorMode("256");
+    const a = applyColor("workflowBrainstorm", "x", fakeTheme, colors);
+    const b = applyColor("workflowWork", "x", fakeTheme, colors);
+    const c = applyColor("workflowReview", "x", fakeTheme, colors);
+    const idx = (s: string) => s.match(/\x1b\[38;5;(\d+)m/)?.[1];
+    assert.ok(idx(a) && idx(b) && idx(c));
+    // The three categories must map to different indices, otherwise the
+    // fix would not restore visual differentiation.
+    assert.notEqual(idx(a), idx(b));
+    assert.notEqual(idx(b), idx(c));
+    assert.notEqual(idx(a), idx(c));
+  });
+});

--- a/packages/utility/src/display/capabilities.ts
+++ b/packages/utility/src/display/capabilities.ts
@@ -42,24 +42,38 @@ function detectColorSupport(): { color: boolean; truecolor: boolean } {
   const term = env.TERM || "";
   const termProgram = env.TERM_PROGRAM || "";
 
-  // Truecolor support
-  const truecolorTerms = [
-    "truecolor",
-    "24bit",
-    "xterm-256color",
-    "screen-256color",
-    "tmux-256color",
-    "alacritty",
-    "kitty",
-    "wezterm",
-    "iTerm",
+  // Apple Terminal.app does NOT support 24-bit truecolor (longstanding
+  // limitation as of macOS 26). Force 256-colour even if some wrapper
+  // leaked COLORTERM=truecolor into the environment.
+  const isAppleTerminal = termProgram === "Apple_Terminal";
+
+  // Truecolor TERM_PROGRAM allow-list. Note: terminfo names like
+  // "xterm-256color" / "screen-256color" / "tmux-256color" advertise
+  // 256-colour, NOT truecolor — they must not appear here.
+  const truecolorTermPrograms = [
+    "iTerm.app",
+    "WezTerm",
+    "Alacritty",
+    "vscode",
+    "Hyper",
+    "Warp",
     "ghostty",
+    "Ghostty",
+    "zed",
+    "Zed",
+    "cursor",
+    "Cursor",
   ];
 
-  const hasTruecolor =
-    env.COLORTERM === "truecolor" ||
-    env.COLORTERM === "24bit" ||
-    truecolorTerms.some((t) => term.includes(t) || termProgram.includes(t));
+  // Truecolor TERM tokens (the rare TERM that *does* advertise truecolor).
+  const truecolorTermTokens = ["truecolor", "24bit", "alacritty", "kitty", "wezterm"];
+
+  const hasTruecolor = isAppleTerminal
+    ? false
+    : env.COLORTERM === "truecolor" ||
+      env.COLORTERM === "24bit" ||
+      truecolorTermPrograms.includes(termProgram) ||
+      truecolorTermTokens.some((t) => term.includes(t));
 
   // Basic color support
   const hasColor =


### PR DESCRIPTION
   ## Summary

   This PR improves UniPi terminal display in two places:

   1. Autocomplete
      - Removes pi source tags like`[u:npm:@pi-unipi/unipi]`
      - Shows full command names like `unipi:brainstorm`
      - Keeps the package tag, e.g. `[workflow]`

   2. Footer colors
      - Adds terminal-aware color rendering
      - Uses truecolor when supported
      - Falls back to xterm-256 colors on terminals that do not support 24-bit color
      - Adds an Apple Terminal fallback
      - Adds `colorMode` support: `auto | truecolor | 256 | none`

   ## Before

   Autocomplete showed:

   ```text
   brainstorm  [u:npm:@pi-unipi/unipi] ...
 ```

 After

 Autocomplete shows:

 ```text
   unipi:brainstorm  [workflow] ...
 ```

 Tests

 ```sh
   npm test --workspace @pi-unipi/command-enchantment
   npm test --workspace @pi-unipi/footer
   npm test --workspace @pi-unipi/utility
 ```
 Results:
 - command-enchantment: 38 passed
 - footer: 52 passed
 - utility: 180 passed
 ```
 ```
<img width="1600" height="799" alt="WhatsApp Image 2026-05-19 at 11 07 32" src="https://github.com/user-attachments/assets/bbeecf92-d0d4-4e6a-aa23-2c86456df29d" />
 ```