### PR TITLE
fix(notify): use pi.events.on() for custom unipi events instead of pi.on()

### DIFF
--- a/packages/notify/events.ts
+++ b/packages/notify/events.ts
@@ -43,6 +43,12 @@ export const BUILTIN_EVENTS: Record<
 };
 
 /**
+ * Pi lifecycle event types (dispatched by ExtensionRunner).
+ * These must use pi.on() — not pi.events.on() — to receive events.
+ */
+const LIFECYCLE_EVENTS = new Set(["agent_end", "session_shutdown"]);
+
+/**
  * Register event listeners for all enabled notification events.
  * Attaches listeners to pi hooks and routes notifications to platforms.
  */
@@ -69,7 +75,31 @@ export function registerEventListeners(
       );
     };
 
-    (pi as any).on(def.hook, handler);
+    // pi lifecycle events (agent_end, session_shutdown) are dispatched via
+    // ExtensionRunner — must use pi.on(). Custom unipi events (unipi:*)
+    // use pi.events.on() (the shared EventBus for extension communication).
+    if (LIFECYCLE_EVENTS.has(eventKey)) {
+      (pi as any).on(def.hook, handler);
+    } else {
+      pi.events.on(def.hook, handler);
+    }
+  }
+
+  // Listen for rpiv:ask-user:prompt from @juicesharp/rpiv-ask-user-question
+  const askUserConfig = config.events["ask_user_prompt"];
+  if (askUserConfig?.enabled) {
+    pi.events.on("rpiv:ask-user:prompt", (payload: unknown) => {
+      const p = payload as Record<string, unknown>;
+      const title = `Pi — ${BUILTIN_EVENTS.ask_user_prompt.label}`;
+      const message = p.context
+        ? `Agent asks: ${String(p.question || "")} — ${String(p.context)}`
+        : `Agent asks: ${String(p.question || "A question")}`;
+      dispatchNotification(pi, title, message, askUserConfig.platforms, "ask_user_prompt", config, cwd).catch(
+        () => {
+          // Silently ignore — background notification failure is non-blocking.
+        }
+      );
+    });
   }
 
   // agent_end — custom handler with session name and recap support
@@ -130,7 +160,7 @@ export function registerEventListeners(
       // For now, modules register their own events through MODULE_READY
     }
   };
-  (pi as any).on(UNIPI_EVENTS.MODULE_READY, moduleHandler);
+  pi.events.on(UNIPI_EVENTS.MODULE_READY, moduleHandler);
 }
 
 /** Get all platforms that are currently enabled in config */

--- a/packages/notify/src/__tests__/event-bus.test.ts
+++ b/packages/notify/src/__tests__/event-bus.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Test: Notify — event bus registration
+ *
+ * Verifies that the notify plugin correctly uses pi.events.on() for custom
+ * unipi events and pi.on() for pi lifecycle events — same pattern enforced
+ * by subagents/badge-generation.test.ts.
+ *
+ * BUG 2 (Wrong event bus):
+ * Cross-module events emitted via pi.events.emit() must be listened via
+ * pi.events.on(), NOT pi.on() (which only dispatches lifecycle events).
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "../../../../");
+
+function readSource(relativePath: string): string {
+  const fullPath = join(ROOT, relativePath);
+  if (!existsSync(fullPath)) throw new Error(`File not found: ${fullPath}`);
+  return readFileSync(fullPath, "utf-8");
+}
+
+// ─── Known lifecycle events (mirrors LIFECYCLE_EVENTS in events.ts) ──
+
+const LIFECYCLE_EVENTS = new Set([
+  "agent_end",
+  "session_shutdown",
+]);
+
+// ─── Test: events.ts correctly uses pi.events.on() for custom events ──
+
+describe("notify — event bus registration", () => {
+  it("events.ts defines LIFECYCLE_EVENTS with correct lifecycle events", () => {
+    const src = readSource("packages/notify/events.ts");
+
+    const lifecycleMatch = src.match(
+      /const LIFECYCLE_EVENTS\s*=\s*new Set\((\[.*?\])\)/s,
+    );
+    assert.ok(lifecycleMatch, "LIFECYCLE_EVENTS should be defined");
+
+    const parsed = [...lifecycleMatch[1].matchAll(/"([^"]+)"/g)].map(
+      (match) => match[1],
+    );
+    assert.deepStrictEqual(
+      parsed.sort(),
+      [...LIFECYCLE_EVENTS].sort(),
+      "LIFECYCLE_EVENTS should contain exactly agent_end and session_shutdown",
+    );
+  });
+
+  it("unipi:* events use pi.events.on(), NOT pi.on()", () => {
+    const src = readSource("packages/notify/events.ts");
+
+    assert.match(
+      src,
+      /pi\.events\.on\(def\.hook,\s*handler\)/,
+      "Custom unipi events should use pi.events.on(def.hook, handler)",
+    );
+
+    assert.doesNotMatch(
+      src,
+      /(?:\(pi\s+as\s+any\)|pi)\.on\s*\(\s*UNIPI_EVENTS\./,
+      "Should NOT use pi.on() for custom unipi events",
+    );
+  });
+
+  it("lifecycle events (agent_end, session_shutdown) still use pi.on()", () => {
+    const src = readSource("packages/notify/events.ts");
+
+    assert.ok(
+      src.includes("LIFECYCLE_EVENTS.has(eventKey)") &&
+        src.includes("(pi as any).on(def.hook, handler)"),
+      "Lifecycle events should be routed through pi.on() in the registration loop",
+    );
+  });
+
+  it("MODULE_READY listener uses pi.events.on()", () => {
+    const src = readSource("packages/notify/events.ts");
+
+    assert.match(
+      src,
+      /pi\.events\s*\.\s*on\s*\(\s*UNIPI_EVENTS\.MODULE_READY/,
+      "MODULE_READY should use pi.events.on()",
+    );
+
+    assert.doesNotMatch(
+      src,
+      /(?:\(pi\s+as\s+any\)|pi)\.on\s*\(\s*UNIPI_EVENTS\.MODULE_READY/,
+      "MODULE_READY should NOT use pi.on()",
+    );
+  });
+});
+
+// ─── Test: index.ts only uses pi.on() for lifecycle events ──────────
+
+describe("notify — index.ts event registration", () => {
+  it("all pi.on() calls in index.ts use lifecycle events only", () => {
+    const src = readSource("packages/notify/index.ts");
+
+    const validLifecycleEvents = [
+      "resources_discover",
+      "session_start",
+      "session_shutdown",
+    ];
+
+    const piOnPattern = /pi\.on\("([^"]+)"/g;
+    let match: RegExpExecArray | null;
+    while ((match = piOnPattern.exec(src)) !== null) {
+      assert.ok(
+        validLifecycleEvents.includes(match[1]),
+        `index.ts: pi.on("${match[1]}") should be a lifecycle event`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
Same bug as `subagents` / `workflow` / `utility` — see `packages/subagents/src/__tests__/badge-generation.test.ts` → "BUG 2 — Wrong event bus" and the `"pi.on() is ONLY used for known lifecycle events"` test block.

`notify` was the only package still using `pi.on()` for custom unipi events (`unipi:workflow:end`, `unipi:ask-user:prompt`, etc.). Fixed to `pi.events.on()` for non-lifecycle events.

This caused users not to receive notifications when using `ask_user_question`.

One-liner: non-lifecycle events → `pi.events.on()` instead of `pi.on()`.