### PR TITLE
fix(notify): adapt rpiv:ask-user:prompt listener to lossless payload contract

### DIFF
--- a/packages/notify/ask-user-prompt-message.ts
+++ b/packages/notify/ask-user-prompt-message.ts
@@ -1,0 +1,48 @@
+/**
+ * @pi-unipi/notify — Internal helper: build notification message from
+ * rpiv:ask-user:prompt event payload.
+ *
+ * @internal — not part of the public API. Shared by the event listener and tests.
+ */
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function nonEmptyString(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim().length > 0 ? value : fallback;
+}
+
+/**
+ * Build a human-readable notification message from an rpiv:ask-user:prompt
+ * payload (lossless format).
+ */
+export function buildAskUserPromptMessage(payload: unknown): string {
+  const p = isRecord(payload) ? payload : {};
+
+  const questions = Array.isArray(p.questions)
+    ? p.questions.filter(isRecord)
+    : [];
+
+  const firstQ = questions[0];
+
+  const baseQuestion = firstQ
+    ? nonEmptyString(firstQ.question, "A question")
+    : "A question";
+
+  const suffix = questions.length > 1 ? ` (+${questions.length - 1} more)` : "";
+
+  const optionLabels =
+    firstQ && Array.isArray(firstQ.options)
+      ? firstQ.options
+          .filter(isRecord)
+          .map((o) => nonEmptyString(o.label, ""))
+          .filter((label) => label.length > 0)
+      : [];
+
+  const options = optionLabels.join(", ");
+
+  return options
+    ? `Agent asks: ${baseQuestion}${suffix} — ${options}`
+    : `Agent asks: ${baseQuestion}${suffix}`;
+}

--- a/packages/notify/events.ts
+++ b/packages/notify/events.ts
@@ -13,7 +13,26 @@ import { sendNativeNotification, SuppressedError } from "./platforms/native.js";
 import { sendGotifyNotification } from "./platforms/gotify.js";
 import { sendTelegramNotification } from "./platforms/telegram.js";
 import { sendNtfyNotification } from "./platforms/ntfy.js";
+import type { AskUserPromptEventPayload } from "@juicesharp/rpiv-ask-user-question/events";
+import { buildAskUserPromptMessage } from "./ask-user-prompt-message.js";
 import { summarizeLastMessage } from "./summarize.js";
+
+// ─── rpiv:ask-user:prompt event contract ──────────────────────────────
+//
+// This event is emitted by @juicesharp/rpiv-ask-user-question before
+// showing the questionnaire UI. UniPi listens to deliver a cross-platform
+// notification so the user knows a question awaits them.
+//
+// Type-only references to the canonical event constant + payload type
+// ensure compile-time drift detection without a hard runtime dependency.
+// -----------------------------------------------------------------------
+
+const ASK_USER_PROMPT_EVENT = "rpiv:ask-user:prompt" satisfies
+  typeof import("@juicesharp/rpiv-ask-user-question/events").ASK_USER_PROMPT_EVENT;
+
+// Payload type check: keeps this file tied to the upstream contract even
+// though we parse defensively at runtime.
+type _AskUserPromptPayload = AskUserPromptEventPayload;
 
 /** Stored session context for modelRegistry access */
 let sessionCtx: ExtensionContext | null = null;
@@ -103,17 +122,9 @@ export function registerEventListeners(
   // Listen for rpiv:ask-user:prompt from @juicesharp/rpiv-ask-user-question
   const askUserConfig = config.events["ask_user_prompt"];
   if (askUserConfig?.enabled) {
-    unsubs.push(pi.events.on("rpiv:ask-user:prompt", (payload: unknown) => {
-      const p =
-        payload && typeof payload === "object"
-          ? (payload as Record<string, unknown>)
-          : {};
+    unsubs.push(pi.events.on(ASK_USER_PROMPT_EVENT, (payload: unknown) => {
       const title = `Pi — ${BUILTIN_EVENTS.ask_user_prompt.label}`;
-      const question = String(p.question ?? "A question");
-      const context = p.context == null ? "" : String(p.context);
-      const message = context
-        ? `Agent asks: ${question} — ${context}`
-        : `Agent asks: ${question}`;
+      const message = buildAskUserPromptMessage(payload);
       dispatchNotification(pi, title, message, askUserConfig.platforms, "ask_user_prompt", config, cwd).catch(
         () => {
           // Silently ignore — background notification failure is non-blocking.
@@ -343,9 +354,7 @@ function buildEventMessage(eventKey: string, payload: unknown): string {
     case "session_shutdown":
       return "Session ending";
     case "ask_user_prompt":
-      return p.context
-        ? `Agent asks: ${String(p.question || "")} — ${String(p.context)}`
-        : `Agent asks: ${String(p.question || "A question")}`;
+      return buildAskUserPromptMessage(payload);
     default:
       return p.message ? String(p.message) : "Event occurred";
   }

--- a/packages/notify/package.json
+++ b/packages/notify/package.json
@@ -19,7 +19,8 @@
     "notifications"
   ],
   "scripts": {
-    "test": "node --experimental-strip-types --test src/__tests__/*.test.ts"
+    "test": "tsc --noEmit && node --experimental-strip-types --test src/__tests__/*.test.ts",
+    "typecheck": "tsc --noEmit"
   },
   "files": [
     "index.ts",
@@ -27,6 +28,7 @@
     "commands.ts",
     "settings.ts",
     "events.ts",
+    "ask-user-prompt-message.ts",
     "ntfy-config.ts",
     "summarize.ts",
     "types.ts",
@@ -45,6 +47,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@juicesharp/rpiv-ask-user-question": "^1.12.0"
   },
   "dependencies": {
     "@pi-unipi/core": "*",

--- a/packages/notify/src/__tests__/ask-user-prompt-message.test.ts
+++ b/packages/notify/src/__tests__/ask-user-prompt-message.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Test: Notify — buildAskUserPromptMessage
+ *
+ * Tests the internal helper directly by importing from its module.
+ * The test fixtures use `satisfies AskUserPromptEventPayload` to
+ * enforce compile-time alignment with the upstream event contract.
+ *
+ * Run: node --experimental-strip-types --test
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { AskUserPromptEventPayload } from "@juicesharp/rpiv-ask-user-question/events";
+import { buildAskUserPromptMessage } from "../../ask-user-prompt-message.ts";
+
+describe("buildAskUserPromptMessage", () => {
+  it("standard lossless payload", () => {
+    const payload = {
+      questions: [
+        {
+          question: "Which library?",
+          header: "Lib",
+          multiSelect: false,
+          options: [
+            { label: "React", description: "UI library", hasPreview: false },
+            { label: "Vue", description: "Another UI library", hasPreview: false },
+          ],
+        },
+      ],
+    } satisfies AskUserPromptEventPayload;
+
+    assert.equal(buildAskUserPromptMessage(payload), "Agent asks: Which library? — React, Vue");
+  });
+
+  it("multiple questions appends (+N more) suffix", () => {
+    const payload = {
+      questions: [
+        {
+          question: "First question",
+          header: "Q1",
+          multiSelect: false,
+          options: [{ label: "A", description: "Option A", hasPreview: false }],
+        },
+        {
+          question: "Second question",
+          header: "Q2",
+          multiSelect: false,
+          options: [{ label: "B", description: "Option B", hasPreview: false }],
+        },
+      ],
+    } satisfies AskUserPromptEventPayload;
+
+    assert.equal(buildAskUserPromptMessage(payload), "Agent asks: First question (+1 more) — A");
+  });
+
+  it("malformed payload (empty question object) falls back to A question", () => {
+    // 故意构造非法 payload，验证运行时降级路径
+    const payload = { questions: [{}] } as unknown as AskUserPromptEventPayload;
+
+    assert.equal(buildAskUserPromptMessage(payload), "Agent asks: A question");
+  });
+
+  it("empty payload falls back to A question", () => {
+    assert.equal(buildAskUserPromptMessage({}), "Agent asks: A question");
+  });
+
+  it("null payload falls back to A question", () => {
+    assert.equal(buildAskUserPromptMessage(null), "Agent asks: A question");
+  });
+
+  it("missing question string in first question falls back", () => {
+    const payload = {
+      questions: [
+        {
+          question: "",
+          header: "H",
+          multiSelect: false,
+          options: [{ label: "Opt", description: "D", hasPreview: false }],
+        },
+      ],
+    } satisfies AskUserPromptEventPayload;
+
+    assert.equal(buildAskUserPromptMessage(payload), "Agent asks: A question — Opt");
+  });
+
+  it("whitespace-only question is treated as missing", () => {
+    const payload = {
+      questions: [
+        {
+          question: "   ",
+          header: "H",
+          multiSelect: false,
+          options: [{ label: "Opt", description: "D", hasPreview: false }],
+        },
+      ],
+    } satisfies AskUserPromptEventPayload;
+
+    // nonEmptyString uses trim().length check, so whitespace-only falls back
+    assert.equal(buildAskUserPromptMessage(payload), "Agent asks: A question — Opt");
+  });
+
+  it("empty option labels do not produce stray commas", () => {
+    const payload = {
+      questions: [
+        {
+          question: "Pick one?",
+          header: "Pick",
+          multiSelect: false,
+          options: [
+            { label: "React", description: "UI lib", hasPreview: false },
+            { label: "", description: "Empty label", hasPreview: false },
+            { label: "Vue", description: "Another UI lib", hasPreview: false },
+          ],
+        },
+      ],
+    } satisfies AskUserPromptEventPayload;
+
+    assert.equal(buildAskUserPromptMessage(payload), "Agent asks: Pick one? — React, Vue");
+  });
+
+  it("no options produces bare question", () => {
+    const payload = {
+      questions: [
+        {
+          question: "Just type?",
+          header: "Free",
+          multiSelect: false,
+          options: [],
+        },
+      ],
+    } satisfies AskUserPromptEventPayload;
+
+    assert.equal(buildAskUserPromptMessage(payload), "Agent asks: Just type?");
+  });
+});


### PR DESCRIPTION
Hi @Neuron-Mr-White,

#12 was opened while the producer-side payload contract was still in flux.

Since then I've synced with the rpiv-ask-user-question maintainer (juicesharp/rpiv-mono#39). The upstream event payload has been finalized as a **lossless projection** of the questionnaire schema — a `questions[]` array carrying full `question`, `header`, `multiSelect`, `options[{label, description, hasPreview}]` — rather than the flattened `question` + `context` strings in #12.

### What this PR does

- **Listener updated** — reads from `payload.questions[0]` instead of `payload.question` / `payload.context`
- **No runtime dependency on rpiv-ask-user-question** — the event contract is referenced via `type-only import` + `satisfies`. The package is only needed for typechecking as a devDependency; no runtime loading occurs.
- **Drift detection** — `tsc --noEmit` runs as a pre-test step. If upstream renames the event or changes the payload shape, it fails at compile time.
- **Shared message builder** — `buildAskUserPromptMessage()` extracted to a dedicated module, used by both the event listener and `buildEventMessage()`, eliminating duplicated formatting logic. Defensive fallbacks handle malformed or missing payload fields at runtime.
- **9 unit tests** — normal payload, multi-question, malformed/empty payloads, edge cases (empty/whitespace-only questions, null payload, empty labels). Tests import the real implementation, not an inline copy.