### PR TITLE
fix(notify): await overlay commands

### DIFF
--- a/packages/notify/commands.ts
+++ b/packages/notify/commands.ts
@@ -34,7 +34,7 @@ export function registerNotifyCommands(pi: ExtensionAPI): void {
           return;
         }
 
-        ctx.ui.custom(
+        await ctx.ui.custom(
           (tui, theme, _keybindings, done) => {
             const overlay = new NotifySettingsOverlay();
             overlay.setTheme(theme);
@@ -42,7 +42,7 @@ export function registerNotifyCommands(pi: ExtensionAPI): void {
             overlay.requestRender = () => tui.requestRender();
             overlay.onOpenModelSelector = () => {
               // Open model selector as nested overlay
-              ctx.ui.custom(
+              void ctx.ui.custom(
                 (innerTui: any, innerTheme: any, _innerKb: any, innerDone: any) => {
                   const selector = new RecapModelSelectorOverlay();
                   selector.setTheme(innerTheme);
@@ -102,7 +102,7 @@ export function registerNotifyCommands(pi: ExtensionAPI): void {
           return;
         }
 
-        ctx.ui.custom(
+        await ctx.ui.custom(
           (tui, theme, _keybindings, done) => {
             const overlay = new RecapModelSelectorOverlay();
             overlay.setTheme(theme);
@@ -142,7 +142,7 @@ export function registerNotifyCommands(pi: ExtensionAPI): void {
           return;
         }
 
-        ctx.ui.custom(
+        await ctx.ui.custom(
           (tui, theme, _keybindings, done) => {
             const overlay = new GotifySetupOverlay();
             overlay.setTheme(theme);
@@ -182,7 +182,7 @@ export function registerNotifyCommands(pi: ExtensionAPI): void {
           return;
         }
 
-        ctx.ui.custom(
+        await ctx.ui.custom(
           (tui, theme, _keybindings, done) => {
             const overlay = new TelegramSetupOverlay();
             overlay.setTheme(theme);
@@ -222,7 +222,7 @@ export function registerNotifyCommands(pi: ExtensionAPI): void {
           return;
         }
 
-        ctx.ui.custom(
+        await ctx.ui.custom(
           (tui, theme, _keybindings, done) => {
             const overlay = new NtfySetupOverlay();
             overlay.setTheme(theme);

--- a/packages/notify/src/__tests__/commands-custom-lifecycle.test.ts
+++ b/packages/notify/src/__tests__/commands-custom-lifecycle.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Test: Notify — custom overlay lifecycle
+ *
+ * ctx.ui.custom() returns a Promise that resolves when the overlay calls done().
+ * Overlay commands must await that Promise so Pi keeps the command/UI lifecycle
+ * alive while the overlay has keyboard focus.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "../../../../");
+
+function readSource(relativePath: string): string {
+	const fullPath = join(ROOT, relativePath);
+	if (!existsSync(fullPath)) throw new Error(`File not found: ${fullPath}`);
+	return readFileSync(fullPath, "utf-8");
+}
+
+describe("notify — custom overlay lifecycle", () => {
+	it("does not launch ctx.ui.custom() without await or void", () => {
+		const src = readSource("packages/notify/commands.ts");
+
+		const bareCustomCalls = src
+			.split("\n")
+			.map((line, index) => ({ line: line.trim(), lineNumber: index + 1 }))
+			.filter(({ line }) => line.startsWith("ctx.ui.custom("));
+
+		assert.deepStrictEqual(
+			bareCustomCalls,
+			[],
+			"ctx.ui.custom() should be awaited for command overlays or explicitly voided for nested fire-and-forget overlays",
+		);
+	});
+
+	it("awaits top-level notify overlay commands", () => {
+		const src = readSource("packages/notify/commands.ts");
+
+		const awaitedOverlayCalls = [...src.matchAll(/await ctx\.ui\.custom\(/g)]
+			.length;
+
+		assert.equal(
+			awaitedOverlayCalls,
+			5,
+			"All five notify overlay commands should await ctx.ui.custom()",
+		);
+	});
+
+	it("marks nested overlay launches as intentional fire-and-forget", () => {
+		const src = readSource("packages/notify/commands.ts");
+
+		assert.match(
+			src,
+			/void ctx\.ui\.custom\(/,
+			"Nested overlay launches should use void ctx.ui.custom() to make the lifecycle choice explicit",
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- Await top-level notify `ctx.ui.custom(...)` overlay calls so command handlers stay alive until overlays close
- Mark the nested recap model selector launch as intentional fire-and-forget with `void`
- Add a regression test that catches bare `ctx.ui.custom(...)` launches in notify commands

## Root Cause
`ctx.ui.custom(...)` returns a Promise that resolves when the overlay calls `done()`. Notify setup/settings commands were launching overlays without awaiting that Promise, which can let the command handler finish while the overlay remains visible. In newer Pi/TUI versions this can leave keyboard focus/input routing unstable for the overlay.

## Testing
- `npm test --workspace packages/notify`
