### PR TITLE
feat(notify): Silence notifications on selected platforms after terminal input

### DIFF
--- a/packages/notify/README.md
+++ b/packages/notify/README.md
@@ -63,7 +63,7 @@ Zero configuration — works out of the box. Set `native.suppressWhenFocused` to
 
 ### Silence after input
 
-After a terminal keypress, listed platforms stay quiet for `windowMs`. Default: **off**, native only, 10s. Edit in `/unipi:notify-settings` → Platforms (在操作后短暂静默 + channel chips), or in `~/.unipi/config/notify/config.json`:
+After a terminal keypress, listed platforms stay quiet for `windowMs`. Default: **off**, native only, 10s. Edit in `/unipi:notify-settings` → Platforms (Quiet after activity + channel chips), or in `~/.unipi/config/notify/config.json`:
 
 ```json
 {

--- a/packages/notify/README.md
+++ b/packages/notify/README.md
@@ -61,6 +61,22 @@ Desktop notifications via [node-notifier](https://github.com/mikaelbr/node-notif
 
 Zero configuration — works out of the box. Set `native.suppressWhenFocused` to `true` to skip native notifications when the active/focused window is already Pi.
 
+### Silence after input
+
+After a terminal keypress, listed platforms stay quiet for `windowMs`. Default: **off**, native only, 10s. Edit in `/unipi:notify-settings` → Platforms (在操作后短暂静默 + channel chips), or in `~/.unipi/config/notify/config.json`:
+
+```json
+{
+  "silenceAfterInput": {
+    "enabled": true,
+    "windowMs": 10000,
+    "platforms": ["native"]
+  }
+}
+```
+
+Add `gotify`, `telegram`, or `ntfy` to `platforms` to silence those channels too. Empty `platforms` silences all enabled platforms (same as `events.*.platforms`).
+
 ### Gotify
 
 Self-hosted push notification server:

--- a/packages/notify/activity.ts
+++ b/packages/notify/activity.ts
@@ -1,0 +1,100 @@
+/**
+ * @pi-unipi/notify — Recent terminal-input activity
+ *
+ * Tracks the last interactive keypress so dispatch can silence selected
+ * platforms while the user is at the keyboard.
+ */
+
+import type {
+  NotifyConfig,
+  NotifyPlatform,
+  SilenceAfterInputConfig,
+} from "./types.js";
+
+/** Known platform names — unknown strings are dropped when merging config. */
+const VALID_PLATFORMS: ReadonlySet<NotifyPlatform> = new Set([
+  "native",
+  "gotify",
+  "telegram",
+  "ntfy",
+]);
+
+let lastInputAt = 0;
+
+/** Record a terminal keypress. `at` is injectable for tests. */
+export function noteInput(at: number = Date.now()): void {
+  lastInputAt = at;
+}
+
+/** Clear activity (session start/shutdown). */
+export function resetInputActivity(): void {
+  lastInputAt = 0;
+}
+
+/**
+ * Split already-enabled platforms into "send" vs "silenced by recent input".
+ * Does not look at platform `enabled` flags — caller filters those first.
+ * Empty `platforms` (while enabled) silences all incoming channels, matching
+ * `events.*.platforms: []` → all enabled.
+ */
+export function filterPlatformsAfterInput(
+  platforms: NotifyPlatform[],
+  config: Pick<NotifyConfig, "silenceAfterInput">,
+  now: number = Date.now(),
+): { send: NotifyPlatform[]; silenced: NotifyPlatform[] } {
+  const cfg = config.silenceAfterInput;
+  if (!shouldSilence(cfg, now)) {
+    return { send: platforms.slice(), silenced: [] };
+  }
+  if (cfg.platforms.length === 0) {
+    return { send: [], silenced: platforms.slice() };
+  }
+  const silent = new Set(cfg.platforms);
+  const send: NotifyPlatform[] = [];
+  const silenced: NotifyPlatform[] = [];
+  for (const platform of platforms) {
+    if (silent.has(platform)) silenced.push(platform);
+    else send.push(platform);
+  }
+  return { send, silenced };
+}
+
+/** Normalize a partial config blob against defaults. */
+export function mergeSilenceAfterInput(
+  loaded: Partial<SilenceAfterInputConfig> | undefined,
+  defaults: SilenceAfterInputConfig,
+): SilenceAfterInputConfig {
+  if (!loaded) {
+    return {
+      enabled: defaults.enabled,
+      windowMs: defaults.windowMs,
+      platforms: defaults.platforms.slice(),
+    };
+  }
+  const platforms = Array.isArray(loaded.platforms)
+    ? loaded.platforms.filter((p): p is NotifyPlatform =>
+        VALID_PLATFORMS.has(p as NotifyPlatform),
+      )
+    : defaults.platforms.slice();
+  const windowMs =
+    typeof loaded.windowMs === "number" &&
+    Number.isFinite(loaded.windowMs) &&
+    loaded.windowMs >= 0
+      ? loaded.windowMs
+      : defaults.windowMs;
+  return {
+    enabled: loaded.enabled ?? defaults.enabled,
+    windowMs,
+    platforms,
+  };
+}
+
+function shouldSilence(
+  cfg: SilenceAfterInputConfig | undefined,
+  now: number,
+): cfg is SilenceAfterInputConfig {
+  if (!cfg?.enabled) return false;
+  if (lastInputAt <= 0) return false;
+  if (now - lastInputAt >= cfg.windowMs) return false;
+  return true;
+}

--- a/packages/notify/events.ts
+++ b/packages/notify/events.ts
@@ -16,6 +16,7 @@ import { sendNtfyNotification } from "./platforms/ntfy.js";
 import { buildAskUserPromptMessage } from "./ask-user-prompt-message.js";
 import { buildPermissionPromptMessage } from "./permission-prompt-message.js";
 import { summarizeLastMessage } from "./summarize.js";
+import { filterPlatformsAfterInput } from "./activity.js";
 
 // Event emitted by @juicesharp/rpiv-ask-user-question before showing its UI.
 // Keep this as a local string until that package publishes an importable
@@ -182,8 +183,11 @@ export async function dispatchNotification(
     return false;
   });
 
+  const { send: platformsToSend, silenced: inputSilenced } =
+    filterPlatformsAfterInput(enabledPlatforms, config);
+
   const results = await Promise.all(
-    enabledPlatforms.map(async (platform) => {
+    platformsToSend.map(async (platform) => {
       try {
         const effectivePriority = await sendToPlatform(platform, title, message, config, cwd, priority);
         return { platform, success: true, ...(effectivePriority === undefined ? {} : { priority: effectivePriority }) };
@@ -201,6 +205,10 @@ export async function dispatchNotification(
       }
     })
   );
+
+  for (const platform of inputSilenced) {
+    results.push({ platform, success: true, suppressed: true });
+  }
 
   const unsuppressed = results.filter((r) => !r.suppressed);
   const allSuccess = results.length > 0 && unsuppressed.every((r) => r.success);

--- a/packages/notify/index.ts
+++ b/packages/notify/index.ts
@@ -24,9 +24,13 @@ import {
   setSessionContext,
   clearSessionContext,
 } from "./events.js";
+import { noteInput, resetInputActivity } from "./activity.js";
 
 /** Package version */
 const VERSION = getPackageVersion(dirname(fileURLToPath(import.meta.url)));
+
+/** Unsubscribe for the interactive-mode keypress listener. */
+let unsubTerminalInput: (() => void) | undefined;
 
 export default function (pi: ExtensionAPI) {
 
@@ -37,6 +41,19 @@ export default function (pi: ExtensionAPI) {
   // Session lifecycle — register events and announce module
   pi.on("session_start", async (_event, ctx) => {
     setSessionContext(ctx);
+    resetInputActivity();
+    unsubTerminalInput?.();
+    unsubTerminalInput = undefined;
+    const onTerminalInput = ctx.ui?.onTerminalInput;
+    if (typeof onTerminalInput === "function") {
+      try {
+        unsubTerminalInput = onTerminalInput(() => {
+          noteInput();
+        });
+      } catch {
+        unsubTerminalInput = undefined;
+      }
+    }
     const cwd = process.cwd();
     const config = loadConfig();
     registerEventListeners(pi, config, cwd);
@@ -51,6 +68,9 @@ export default function (pi: ExtensionAPI) {
 
   // Cleanup on session shutdown
   pi.on("session_shutdown", async () => {
+    unsubTerminalInput?.();
+    unsubTerminalInput = undefined;
+    resetInputActivity();
     clearSessionContext();
     unregisterEventListeners();
   });

--- a/packages/notify/settings.ts
+++ b/packages/notify/settings.ts
@@ -8,6 +8,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { dirname, join } from "path";
 import { homedir } from "os";
 import { NOTIFY_DIRS } from "@pi-unipi/core";
+import { mergeSilenceAfterInput } from "./activity.js";
 import type { NotifyConfig } from "./types.js";
 
 /** Resolve config path (expands ~ to homedir) */
@@ -44,6 +45,11 @@ export const DEFAULT_CONFIG: NotifyConfig = {
   recap: {
     enabled: false,
     model: "openrouter/openai/gpt-oss-20b",
+  },
+  silenceAfterInput: {
+    enabled: false,
+    windowMs: 10000,
+    platforms: ["native"],
   },
 };
 
@@ -117,5 +123,9 @@ function mergeWithDefaults(loaded: Partial<NotifyConfig>): NotifyConfig {
     gotify: { ...DEFAULT_CONFIG.gotify, ...loaded.gotify },
     telegram: { ...DEFAULT_CONFIG.telegram, ...loaded.telegram },
     recap: { ...DEFAULT_CONFIG.recap, ...loaded.recap },
+    silenceAfterInput: mergeSilenceAfterInput(
+      loaded.silenceAfterInput,
+      DEFAULT_CONFIG.silenceAfterInput,
+    ),
   };
 }

--- a/packages/notify/skills/configure-notify/SKILL.md
+++ b/packages/notify/skills/configure-notify/SKILL.md
@@ -93,7 +93,7 @@ Quiet listed platforms for `windowMs` after any terminal keypress. **Default: of
 - `windowMs` — quiet window in milliseconds (default: 10000)
 - `platforms` — channels to silence (`native`, `gotify`, `telegram`, `ntfy`). Empty list silences all enabled platforms (same as `events.*.platforms`).
 
-TUI: `/unipi:notify-settings` → Platforms → 在操作后短暂静默 (Space), ←→ then Space for channels, +/− for the window (1s steps).
+TUI: `/unipi:notify-settings` → Platforms → Quiet after activity (Space), ←→ then Space for channels, +/− for the window (1s steps).
 
 ### Gotify (default: disabled)
 

--- a/packages/notify/skills/configure-notify/SKILL.md
+++ b/packages/notify/skills/configure-notify/SKILL.md
@@ -62,6 +62,11 @@ Help users configure the `@pi-unipi/notify` notification system.
     "token": null,
     "priority": 3
   },
+  "silenceAfterInput": {
+    "enabled": false,
+    "windowMs": 10000,
+    "platforms": ["native"]
+  },
   "NOTE": "ntfy section is legacy — migrated to ntfy.json on first run"
 }
 ```
@@ -71,6 +76,24 @@ Help users configure the `@pi-unipi/notify` notification system.
 ### Native OS (default: enabled)
 
 Desktop notifications via node-notifier. Works out of the box on Windows, macOS, Linux.
+
+### Silence after input
+
+Quiet listed platforms for `windowMs` after any terminal keypress. **Default: off.** Same `config.json` as other notify settings.
+
+```json
+"silenceAfterInput": {
+  "enabled": true,
+  "windowMs": 10000,
+  "platforms": ["native"]
+}
+```
+
+- `enabled` — master switch
+- `windowMs` — quiet window in milliseconds (default: 10000)
+- `platforms` — channels to silence (`native`, `gotify`, `telegram`, `ntfy`). Empty list silences all enabled platforms (same as `events.*.platforms`).
+
+TUI: `/unipi:notify-settings` → Platforms → 在操作后短暂静默 (Space), ←→ then Space for channels, +/− for the window (1s steps).
 
 ### Gotify (default: disabled)
 

--- a/packages/notify/src/__tests__/activity.test.ts
+++ b/packages/notify/src/__tests__/activity.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for silence-after-input: per-channel filtering after a keypress.
+ */
+
+import { beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  filterPlatformsAfterInput,
+  mergeSilenceAfterInput,
+  noteInput,
+  resetInputActivity,
+} from "../../activity.ts";
+import type { NotifyPlatform, SilenceAfterInputConfig } from "../../types.ts";
+
+const DEFAULTS: SilenceAfterInputConfig = {
+  enabled: true,
+  windowMs: 10000,
+  platforms: ["native"],
+};
+
+function config(partial?: Partial<SilenceAfterInputConfig>) {
+  return {
+    silenceAfterInput: mergeSilenceAfterInput(partial, DEFAULTS),
+  };
+}
+
+const ALL: NotifyPlatform[] = ["native", "gotify", "telegram", "ntfy"];
+
+describe("silence after input", () => {
+  beforeEach(() => {
+    resetInputActivity();
+  });
+
+  it("does not silence before any keypress", () => {
+    const { send, silenced } = filterPlatformsAfterInput(ALL, config(), 1_000);
+    assert.deepEqual(send, ALL);
+    assert.deepEqual(silenced, []);
+  });
+
+  it("silences only listed platforms inside the window", () => {
+    noteInput(1_000);
+    const { send, silenced } = filterPlatformsAfterInput(
+      ALL,
+      config(),
+      1_000 + 100,
+    );
+    assert.deepEqual(send, ["gotify", "telegram", "ntfy"]);
+    assert.deepEqual(silenced, ["native"]);
+  });
+
+  it("lets every listed channel opt in independently", () => {
+    noteInput(1_000);
+    const { send, silenced } = filterPlatformsAfterInput(
+      ALL,
+      config({ platforms: ["native", "telegram"] }),
+      1_000 + 100,
+    );
+    assert.deepEqual(send, ["gotify", "ntfy"]);
+    assert.deepEqual(silenced, ["native", "telegram"]);
+  });
+
+  it("stops silencing once the window elapses", () => {
+    noteInput(1_000);
+    const { send, silenced } = filterPlatformsAfterInput(
+      ALL,
+      config(),
+      1_000 + 10_000,
+    );
+    assert.deepEqual(send, ALL);
+    assert.deepEqual(silenced, []);
+  });
+
+  it("does nothing when disabled", () => {
+    noteInput(1_000);
+    const { send, silenced } = filterPlatformsAfterInput(
+      ALL,
+      config({ enabled: false }),
+      1_000 + 100,
+    );
+    assert.deepEqual(send, ALL);
+    assert.deepEqual(silenced, []);
+  });
+
+  it("silences all enabled platforms when platforms is empty", () => {
+    noteInput(1_000);
+    const { send, silenced } = filterPlatformsAfterInput(
+      ALL,
+      config({ platforms: [] }),
+      1_000 + 100,
+    );
+    assert.deepEqual(send, []);
+    assert.deepEqual(silenced, ALL);
+  });
+
+  it("preserves an explicit empty platforms array when merging", () => {
+    const merged = mergeSilenceAfterInput({ platforms: [] }, DEFAULTS);
+    assert.deepEqual(merged.platforms, []);
+  });
+
+  it("uses defaults when the config key is missing", () => {
+    const merged = mergeSilenceAfterInput(undefined, DEFAULTS);
+    assert.deepEqual(merged, DEFAULTS);
+  });
+
+  it("keeps enabled:false and falls back invalid windowMs", () => {
+    const merged = mergeSilenceAfterInput(
+      { enabled: false, windowMs: -1 },
+      DEFAULTS,
+    );
+    assert.equal(merged.enabled, false);
+    assert.equal(merged.windowMs, 10000);
+    assert.deepEqual(merged.platforms, ["native"]);
+  });
+
+  it("drops unknown platform names when merging", () => {
+    const merged = mergeSilenceAfterInput(
+      { platforms: ["native", "pagerduty", "ntfy"] as NotifyPlatform[] },
+      DEFAULTS,
+    );
+    assert.deepEqual(merged.platforms, ["native", "ntfy"]);
+  });
+});

--- a/packages/notify/src/__tests__/tui-input.test.ts
+++ b/packages/notify/src/__tests__/tui-input.test.ts
@@ -235,6 +235,107 @@ describe("settings overlay: toggle, tab, model-selector key, save", () => {
   });
 });
 
+function goToSilenceMaster(overlay: NotifySettingsOverlay): void {
+  for (let i = 0; i < 5; i++) overlay.handleInput("j");
+}
+
+function goToSilenceChips(overlay: NotifySettingsOverlay): void {
+  for (let i = 0; i < 6; i++) overlay.handleInput("j");
+}
+
+describe("settings overlay: silence after input", () => {
+  it("reaches the master row and chip row with j", () => {
+    freshHome();
+    const overlay = new NotifySettingsOverlay();
+    goToSilenceMaster(overlay);
+    assert.ok(
+      selectedLine(overlay).includes("在操作后短暂静默"),
+      "5 downs land on the silence master row",
+    );
+    overlay.handleInput("j");
+    const chips = stripAnsi(selectedLine(overlay));
+    assert.ok(chips.includes("Native"), "6th down lands on the chip row");
+    assert.ok(chips.includes("Gotify") && chips.includes("Telegram") && chips.includes("ntfy"));
+  });
+
+  it("Space on the master row toggles enabled", () => {
+    freshHome();
+    const overlay = new NotifySettingsOverlay();
+    goToSilenceMaster(overlay);
+    assert.ok(selectedLine(overlay).includes("○"), "disabled by default");
+    overlay.handleInput(" ");
+    assert.ok(selectedLine(overlay).includes("●"), "Space enables");
+    overlay.handleInput(" ");
+    assert.ok(selectedLine(overlay).includes("○"), "Space disables again");
+  });
+
+  it("+ / - on the master row nudge the window", () => {
+    freshHome();
+    const overlay = new NotifySettingsOverlay();
+    goToSilenceMaster(overlay);
+    assert.ok(stripAnsi(selectedLine(overlay)).includes("10s"), "default 10s");
+    overlay.handleInput("+");
+    assert.ok(stripAnsi(selectedLine(overlay)).includes("11s"), "+ steps 1s");
+    overlay.handleInput("-");
+    overlay.handleInput("-");
+    assert.ok(stripAnsi(selectedLine(overlay)).includes("9s"), "- steps down");
+  });
+
+  it("h / l move the focused chip and Space toggles membership", () => {
+    freshHome();
+    const overlay = new NotifySettingsOverlay();
+    goToSilenceChips(overlay);
+    const start = stripAnsi(selectedLine(overlay));
+    assert.ok(start.includes("[● Native]"), "focus starts on Native");
+    overlay.handleInput("l");
+    assert.ok(
+      stripAnsi(selectedLine(overlay)).includes("[○ Gotify]"),
+      "l moves focus to Gotify",
+    );
+    overlay.handleInput(" ");
+    assert.ok(
+      stripAnsi(selectedLine(overlay)).includes("[● Gotify]"),
+      "Space adds Gotify to the list",
+    );
+    overlay.handleInput("h");
+    overlay.handleInput(" ");
+    // Native was the default sole member; unchecking it while Gotify is on is allowed
+    assert.ok(
+      stripAnsi(selectedLine(overlay)).includes("[○ Native]"),
+      "Space removes Native when another chip is on",
+    );
+  });
+
+  it("blocks unchecking the last remaining chip", () => {
+    freshHome();
+    const overlay = new NotifySettingsOverlay();
+    goToSilenceChips(overlay);
+    overlay.handleInput(" "); // try to turn Native off while it is the only member
+    assert.ok(
+      stripAnsi(selectedLine(overlay)).includes("[● Native]"),
+      "last chip stays on",
+    );
+  });
+
+  it("saves all four chips as an empty platforms array", () => {
+    freshHome();
+    const overlay = new NotifySettingsOverlay();
+    goToSilenceChips(overlay);
+    overlay.handleInput("l");
+    overlay.handleInput(" "); // gotify
+    overlay.handleInput("l");
+    overlay.handleInput(" "); // telegram
+    overlay.handleInput("l");
+    overlay.handleInput(" "); // ntfy
+    overlay.handleInput(ENTER_ENCODINGS[0]);
+    const cfg = readNotifyConfig() as {
+      silenceAfterInput: { enabled: boolean; platforms: string[] };
+    };
+    assert.equal(cfg.silenceAfterInput.enabled, false);
+    assert.deepEqual(cfg.silenceAfterInput.platforms, []);
+  });
+});
+
 // ─── Recap model selector: navigation, close, filter ───────────────────────
 
 describe("model selector: navigation & close (issue #27 bug 1)", () => {

--- a/packages/notify/src/__tests__/tui-input.test.ts
+++ b/packages/notify/src/__tests__/tui-input.test.ts
@@ -249,7 +249,7 @@ describe("settings overlay: silence after input", () => {
     const overlay = new NotifySettingsOverlay();
     goToSilenceMaster(overlay);
     assert.ok(
-      selectedLine(overlay).includes("在操作后短暂静默"),
+      selectedLine(overlay).includes("Quiet after activity"),
       "5 downs land on the silence master row",
     );
     overlay.handleInput("j");

--- a/packages/notify/tui/settings-overlay.ts
+++ b/packages/notify/tui/settings-overlay.ts
@@ -369,8 +369,8 @@ export class NotifySettingsOverlay implements Component {
       ? this.overlay.fg("success", "●")
       : this.overlay.fg("dim", "○");
     const label = masterSelected
-      ? this.overlay.bold("在操作后短暂静默")
-      : this.overlay.fg("dim", "在操作后短暂静默");
+      ? this.overlay.bold("Quiet after activity")
+      : this.overlay.fg("dim", "Quiet after activity");
     const detail = this.overlay.fg("dim", this.silenceSummary());
     lines.push(
       this.overlay.frameLine(

--- a/packages/notify/tui/settings-overlay.ts
+++ b/packages/notify/tui/settings-overlay.ts
@@ -14,11 +14,27 @@ import {
   validateConfig,
 } from "../settings.js";
 import { loadNtfyConfig, saveNtfyConfig, getNtfyConfigScope } from "../ntfy-config.js";
-import type { NotifyConfig, NtfyConfig } from "../types.js";
+import type { NotifyConfig, NotifyPlatform, NtfyConfig } from "../types.js";
 import { OverlayTheme, boxInnerWidth } from "@pi-unipi/core";
 
 /** Section types */
 type Section = "platforms" | "events" | "recap";
+
+const PLATFORM_KEYS: NotifyPlatform[] = ["native", "gotify", "telegram", "ntfy"];
+const CHIP_LABELS: Record<NotifyPlatform, string> = {
+  native: "Native",
+  gotify: "Gotify",
+  telegram: "Telegram",
+  ntfy: "ntfy",
+};
+
+const SUPPRESS_FOCUSED_INDEX = 4;
+const SILENCE_MASTER_INDEX = 5;
+const SILENCE_CHIPS_INDEX = 6;
+
+const WINDOW_STEP_MS = 1_000;
+const WINDOW_MIN_MS = 1_000;
+const WINDOW_MAX_MS = 120_000;
 
 /**
  * Settings overlay component.
@@ -29,6 +45,8 @@ export class NotifySettingsOverlay implements Component {
   private ntfyScope: "project" | "global" | "none";
   private section: Section = "platforms";
   private selectedIndex = 0;
+  /** Which silence-after-input chip is focused (0–3). */
+  private chipIndex = 0;
   private error: string | null = null;
   private saved = false;
   onClose?: () => void;
@@ -70,6 +88,26 @@ export class NotifySettingsOverlay implements Component {
       this.selectedIndex = Math.min(this.maxItems - 1, this.selectedIndex + 1);
       return;
     }
+    if (this.section === "platforms" && this.selectedIndex === SILENCE_CHIPS_INDEX) {
+      if (matchesKey(data, "left") || data === "h") {
+        this.chipIndex = Math.max(0, this.chipIndex - 1);
+        return;
+      }
+      if (matchesKey(data, "right") || data === "l") {
+        this.chipIndex = Math.min(PLATFORM_KEYS.length - 1, this.chipIndex + 1);
+        return;
+      }
+    }
+    if (this.section === "platforms" && this.selectedIndex === SILENCE_MASTER_INDEX) {
+      if (data === "+" || data === "=") {
+        this.nudgeWindow(WINDOW_STEP_MS);
+        return;
+      }
+      if (data === "-" || data === "_") {
+        this.nudgeWindow(-WINDOW_STEP_MS);
+        return;
+      }
+    }
     if (matchesKey(data, "space")) {
       this.toggleCurrent();
       return;
@@ -99,30 +137,57 @@ export class NotifySettingsOverlay implements Component {
   }
 
   private get maxItems(): number {
-    if (this.section === "platforms") return 5; // native, gotify, telegram, ntfy + suppress option
+    if (this.section === "platforms") return 7; // 4 platforms + focused + silence master + chips
     if (this.section === "recap") return 1; // toggle
     return Object.keys(this.config.events).length;
   }
 
+  private nudgeWindow(delta: number): void {
+    const current = this.config.silenceAfterInput.windowMs;
+    this.config.silenceAfterInput.windowMs = Math.min(
+      WINDOW_MAX_MS,
+      Math.max(WINDOW_MIN_MS, current + delta),
+    );
+  }
+
+  private chipOn(key: NotifyPlatform): boolean {
+    const listed = this.config.silenceAfterInput.platforms;
+    if (listed.length === 0) return true;
+    return listed.includes(key);
+  }
+
+  private toggleSilenceChip(key: NotifyPlatform): void {
+    const listed = this.config.silenceAfterInput.platforms;
+    const effective = listed.length === 0 ? PLATFORM_KEYS.slice() : listed.slice();
+    const idx = effective.indexOf(key);
+    if (idx >= 0) {
+      if (effective.length === 1) return;
+      effective.splice(idx, 1);
+    } else {
+      effective.push(key);
+    }
+    const ordered = PLATFORM_KEYS.filter((p) => effective.includes(p));
+    this.config.silenceAfterInput.platforms =
+      ordered.length === PLATFORM_KEYS.length ? [] : ordered;
+  }
+
   private toggleCurrent(): void {
     if (this.section === "platforms") {
-      const platforms: Array<"native" | "gotify" | "telegram" | "ntfy"> = [
-        "native",
-        "gotify",
-        "telegram",
-        "ntfy",
-      ];
-      if (this.selectedIndex < platforms.length) {
-        const key = platforms[this.selectedIndex];
+      if (this.selectedIndex < PLATFORM_KEYS.length) {
+        const key = PLATFORM_KEYS[this.selectedIndex];
         if (key === "ntfy") {
           // ntfy toggle updates the resolved ntfy config
           this.ntfyConfig.enabled = !this.ntfyConfig.enabled;
         } else if (key) {
           this.config[key].enabled = !this.config[key].enabled;
         }
-      } else {
-        // suppressWhenFocused toggle (index 4)
+      } else if (this.selectedIndex === SUPPRESS_FOCUSED_INDEX) {
         this.config.native.suppressWhenFocused = !this.config.native.suppressWhenFocused;
+      } else if (this.selectedIndex === SILENCE_MASTER_INDEX) {
+        this.config.silenceAfterInput.enabled = !this.config.silenceAfterInput.enabled;
+      } else if (this.selectedIndex === SILENCE_CHIPS_INDEX) {
+        const key = PLATFORM_KEYS[this.chipIndex];
+        if (key) this.toggleSilenceChip(key);
       }
     } else if (this.section === "recap") {
       this.config.recap.enabled = !this.config.recap.enabled;
@@ -196,18 +261,35 @@ export class NotifySettingsOverlay implements Component {
 
     // Footer
     lines.push(this.overlay.ruleLine(innerWidth));
-    const footerHint = this.section === "recap"
-      ? "↑↓ navigate · Space toggle · M change model · Tab switch · Enter save · Esc cancel"
-      : "↑↓ navigate · Space toggle · Tab switch · Enter save · Esc cancel";
-    lines.push(this.overlay.frameLine(this.overlay.fg("dim", footerHint), innerWidth));
+    lines.push(this.overlay.frameLine(this.overlay.fg("dim", this.footerHint()), innerWidth));
     lines.push(this.overlay.borderLine(innerWidth, "bottom"));
 
     return lines;
   }
 
+  private footerHint(): string {
+    if (this.section === "recap") {
+      return "↑↓ navigate · Space toggle · M change model · Tab switch · Enter save · Esc cancel";
+    }
+    if (this.section === "platforms" && this.selectedIndex === SILENCE_MASTER_INDEX) {
+      return "↑↓ navigate · Space toggle · +/− window · Tab switch · Enter save · Esc cancel";
+    }
+    if (this.section === "platforms" && this.selectedIndex === SILENCE_CHIPS_INDEX) {
+      return "↑↓ navigate · ←→ channel · Space toggle · Tab switch · Enter save · Esc cancel";
+    }
+    return "↑↓ navigate · Space toggle · Tab switch · Enter save · Esc cancel";
+  }
+
+  private silenceSummary(): string {
+    const seconds = Math.round(this.config.silenceAfterInput.windowMs / 1000);
+    const listed = this.config.silenceAfterInput.platforms;
+    const scope = listed.length === 0 ? "all enabled" : listed.join(", ");
+    return `${seconds}s · ${scope}`;
+  }
+
   private renderPlatforms(lines: string[], innerWidth: number): void {
     const platforms: Array<{
-      key: "native" | "gotify" | "telegram" | "ntfy";
+      key: NotifyPlatform;
       label: string;
       detail: string;
     }> = [
@@ -259,8 +341,7 @@ export class NotifySettingsOverlay implements Component {
 
     // suppressWhenFocused toggle (index 4)
     {
-      const i = platforms.length;
-      const isSelected = i === this.selectedIndex;
+      const isSelected = this.selectedIndex === SUPPRESS_FOCUSED_INDEX;
       const isEnabled = this.config.native.suppressWhenFocused === true;
       const toggleOn = this.overlay.fg("success", "●");
       const toggleOff = this.overlay.fg("dim", "○");
@@ -277,6 +358,47 @@ export class NotifySettingsOverlay implements Component {
         )
       );
     }
+
+    this.renderSilenceAfterInput(lines, innerWidth);
+  }
+
+  private renderSilenceAfterInput(lines: string[], innerWidth: number): void {
+    const masterOn = this.config.silenceAfterInput.enabled;
+    const masterSelected = this.selectedIndex === SILENCE_MASTER_INDEX;
+    const toggle = masterOn
+      ? this.overlay.fg("success", "●")
+      : this.overlay.fg("dim", "○");
+    const label = masterSelected
+      ? this.overlay.bold("在操作后短暂静默")
+      : this.overlay.fg("dim", "在操作后短暂静默");
+    const detail = this.overlay.fg("dim", this.silenceSummary());
+    lines.push(
+      this.overlay.frameLine(
+        `${masterSelected ? this.overlay.fg("accent", "▸") : " "} ${toggle} ${label}  ${detail}`,
+        innerWidth,
+      ),
+    );
+
+    const chipsSelected = this.selectedIndex === SILENCE_CHIPS_INDEX;
+    const chips = PLATFORM_KEYS.map((key, i) => {
+      const on = this.chipOn(key);
+      const mark = on ? "●" : "○";
+      const text = `${mark} ${CHIP_LABELS[key]}`;
+      const focused = chipsSelected && i === this.chipIndex;
+      if (focused) {
+        return this.overlay.fg("accent", this.overlay.bold(`[${text}]`));
+      }
+      const painted = on
+        ? `${this.overlay.fg("success", mark)} ${CHIP_LABELS[key]}`
+        : this.overlay.fg("dim", text);
+      return masterOn ? painted : this.overlay.fg("dim", text);
+    });
+    lines.push(
+      this.overlay.frameLine(
+        `${chipsSelected ? this.overlay.fg("accent", "▸") : " "}   ${chips.join("  ")}`,
+        innerWidth,
+      ),
+    );
   }
 
   private renderEvents(lines: string[], innerWidth: number): void {

--- a/packages/notify/types.ts
+++ b/packages/notify/types.ts
@@ -71,6 +71,16 @@ export interface RecapConfig {
   model: string;
 }
 
+/** Quiet listed platforms after recent terminal input */
+export interface SilenceAfterInputConfig {
+  /** Master switch */
+  enabled: boolean;
+  /** Quiet window after the last keypress, in milliseconds */
+  windowMs: number;
+  /** Platforms to suppress (empty = all enabled platforms) */
+  platforms: NotifyPlatform[];
+}
+
 /** Full notification configuration */
 export interface NotifyConfig {
   /** Global default platforms for all events */
@@ -85,6 +95,8 @@ export interface NotifyConfig {
   telegram: TelegramConfig;
   /** Recap summarization settings */
   recap: RecapConfig;
+  /** Suppress listed platforms after recent terminal input */
+  silenceAfterInput: SilenceAfterInputConfig;
 }
 
 /** Parameters for the notify_user agent tool */


### PR DESCRIPTION
## Problem

When the agent emits several tool calls that each need a permission prompt, notifications fire **one after another as the user answers**. The first toast is useful (bring me back). The rest are noise — the user is already at the keyboard.

This is not a parallel burst: `permissions:ui_prompt` is sequential. A debounce/coalesce window would miss it. Notify also should not subscribe to `@gotgenes/pi-permission-system`; the signal has to be Pi-native.

## Solution

After any interactive terminal keypress (`ctx.ui.onTerminalInput`), listed platforms stay quiet for a short window.

- First prompt while the user is away → still notifies (last keypress is older than the window).
- User hits allow/deny → next prompt inside the window is suppressed on the configured channels.
- Other channels (e.g. Telegram) can keep firing if they are not in `platforms`.

`suppressWhenFocused` is unchanged; the two gates are OR’d for native.

## Config

`~/.unipi/config/notify/config.json`:

```json
"silenceAfterInput": {
  "enabled": false,
  "windowMs": 10000,
  "platforms": ["native"]
}
```

| Field | Default | Notes |
| --- | --- | --- |
| `enabled` | `false` | opt-in |
| `windowMs` | `10000` | 10s |
| `platforms` | `["native"]` | channels to mute; **empty array = all currently enabled platforms** (same as `events.*.platforms`) |

Unknown platform names are dropped on merge so the list can grow later.

## TUI

`/unipi:notify-settings` → Platforms, after “Suppress when focused”:

- Master row **Quiet after activity** — Space toggles; `+`/`-` adjust the window in **1s** steps (1–120s).
- One horizontal chip row: Native / Gotify / Telegram / ntfy — `←`/`→` (or `h`/`l`) then Space.
- All four chips on → saved as `platforms: []`.
- The last remaining chip cannot be unchecked.

## Tests

- `packages/notify/src/__tests__/activity.test.ts` — window, per-channel filter, empty list, merge.
- `packages/notify/src/__tests__/tui-input.test.ts` — overlay navigation, chips, save `[]`.

## Out of scope

- No `permissions:*` listeners.
- No new UniPi package.
- `ask_user_prompt` / `notify_user` not special-cased (same presence window applies to every dispatch).
